### PR TITLE
feat: close local-dev, plugin, routing, and session usage gaps

### DIFF
--- a/agent/src/models/router.ts
+++ b/agent/src/models/router.ts
@@ -28,6 +28,17 @@ export interface RouteResult {
   complexity: ComplexityTier;
 }
 
+export interface ModelTarget {
+  provider: ModelProvider;
+  model: string;
+}
+
+export interface FailoverRoute {
+  primary: ModelTarget;
+  fallbacks: ModelTarget[];
+  complexity: ComplexityTier;
+}
+
 export type ComplexityTier = "simple" | "moderate" | "complex";
 
 // ─── Complexity Thresholds ──────────────────────────────────────────────────
@@ -45,6 +56,12 @@ const DEFAULT_MODELS: Record<ComplexityTier, string> = {
   simple: "claude-haiku-4-20250514",
   moderate: "claude-sonnet-4-20250514",
   complex: "claude-sonnet-4-20250514",
+};
+
+const DEFAULT_FALLBACK_MODELS: Record<ComplexityTier, string[]> = {
+  simple: ["gpt-4o-mini", "claude-sonnet-4-20250514"],
+  moderate: ["gpt-4o", "claude-haiku-4-20250514"],
+  complex: ["gpt-4o", "claude-opus-4-20250514"],
 };
 
 // ─── Provider Cache ─────────────────────────────────────────────────────────
@@ -152,6 +169,33 @@ export function routeModel(message: string, agent?: AgentConfig): RouteResult {
   );
 
   return { provider, model, complexity };
+}
+
+export function buildFailoverChain(
+  message: string,
+  agent?: AgentConfig,
+  fallbackModels?: string[],
+): FailoverRoute {
+  const primary = routeModel(message, agent);
+  const desiredFallbacks = fallbackModels ?? DEFAULT_FALLBACK_MODELS[primary.complexity];
+  const seen = new Set([primary.model]);
+  const fallbacks: ModelTarget[] = [];
+
+  for (const model of desiredFallbacks) {
+    if (seen.has(model)) continue;
+    seen.add(model);
+    const providerName = inferProvider(model);
+    fallbacks.push({
+      model,
+      provider: getProvider(providerName),
+    });
+  }
+
+  return {
+    primary: { provider: primary.provider, model: primary.model },
+    fallbacks,
+    complexity: primary.complexity,
+  };
 }
 
 /**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,11 +19,21 @@ services:
       - REDIS_URL=redis://redis:6379
     volumes:
       - karna-data:/root/.karna
+      - ./gateway:/app/gateway
+      - ./agent:/app/agent
+      - ./packages:/app/packages
     depends_on:
       supabase-db:
         condition: service_healthy
       redis:
         condition: service_healthy
+      supabase-auth:
+        condition: service_started
+    healthcheck:
+      test: ["CMD-SHELL", "node -e \"fetch('http://127.0.0.1:18789/health').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))\""]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     restart: unless-stopped
 
   supabase-db:
@@ -74,6 +84,11 @@ services:
     depends_on:
       supabase-db:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget --spider -q http://127.0.0.1:9999/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     restart: unless-stopped
 
   redis:

--- a/packages/payments/src/index.ts
+++ b/packages/payments/src/index.ts
@@ -55,5 +55,6 @@ export {
   type UsageRecord,
   type UsageReport,
   type LimitCheckResult,
+  type SessionLimitCheckResult,
   type UsageStore,
 } from "./usage.js";

--- a/packages/payments/src/usage.ts
+++ b/packages/payments/src/usage.ts
@@ -42,6 +42,10 @@ export interface LimitCheckResult {
   resetAt: Date;
 }
 
+export interface SessionLimitCheckResult extends LimitCheckResult {
+  sessionId: string;
+}
+
 export interface UsageStore {
   increment(key: string, field: string, amount: number): Promise<number>;
   get(key: string, field: string): Promise<number>;
@@ -123,6 +127,19 @@ export class UsageMeter {
     return count;
   }
 
+  async trackSessionMessage(agentId: string, sessionId: string, channel: string): Promise<number> {
+    if (!sessionId) throw new Error("Session ID is required");
+
+    const dateKey = this.getDateKey();
+    const bucketKey = this.getSessionBucketKey(agentId, sessionId, dateKey);
+
+    const count = await this.store.increment(bucketKey, "messages", 1);
+    await this.store.increment(bucketKey, `messages:${channel}`, 1);
+
+    logger.debug({ agentId, sessionId, channel, totalMessages: count }, "Session message tracked");
+    return count;
+  }
+
   async trackTokens(agentId: string, inputTokens: number, outputTokens: number): Promise<void> {
     if (!agentId) throw new Error("Agent ID is required");
     if (inputTokens < 0 || outputTokens < 0) throw new Error("Token counts must be non-negative");
@@ -189,6 +206,55 @@ export class UsageMeter {
     };
   }
 
+  async getSessionUsage(agentId: string, sessionId: string, period: UsagePeriod = "daily"): Promise<UsageReport> {
+    if (!agentId) throw new Error("Agent ID is required");
+    if (!sessionId) throw new Error("Session ID is required");
+
+    const now = new Date();
+    const dates = period === "daily" ? [this.getDateKey(now)] : this.getMonthDates(now);
+    const daily: UsageRecord[] = [];
+    let totalMessages = 0;
+    let totalTokensIn = 0;
+    let totalTokensOut = 0;
+
+    for (const date of dates) {
+      const bucketKey = this.getSessionBucketKey(agentId, sessionId, date);
+      const data = await this.store.getAll(bucketKey);
+      const messages = data["messages"] ?? 0;
+      const tokensIn = data["tokens_in"] ?? 0;
+      const tokensOut = data["tokens_out"] ?? 0;
+
+      totalMessages += messages;
+      totalTokensIn += tokensIn;
+      totalTokensOut += tokensOut;
+
+      if (messages > 0 || tokensIn > 0 || tokensOut > 0) {
+        daily.push({
+          agentId,
+          channel: "session",
+          messages,
+          tokensIn,
+          tokensOut,
+          date,
+        });
+      }
+    }
+
+    const costCents = Math.ceil((totalTokensIn * 0.3 + totalTokensOut * 1.5) / 100_000);
+
+    return {
+      agentId,
+      period,
+      startDate: dates[0] ?? this.getDateKey(now),
+      endDate: dates[dates.length - 1] ?? this.getDateKey(now),
+      totalMessages,
+      totalTokensIn,
+      totalTokensOut,
+      costCents,
+      daily,
+    };
+  }
+
   // ─── Limit Checks ──────────────────────────────────────────────────────
 
   async checkLimits(agentId: string, plan: PlanId): Promise<LimitCheckResult> {
@@ -219,6 +285,30 @@ export class UsageMeter {
     return { allowed, remaining, limit, used: totalMessages, resetAt };
   }
 
+  async checkSessionLimits(
+    agentId: string,
+    sessionId: string,
+    sessionMessageLimit: number,
+  ): Promise<SessionLimitCheckResult> {
+    if (!sessionId) throw new Error("Session ID is required");
+
+    const dateKey = this.getDateKey();
+    const bucketKey = this.getSessionBucketKey(agentId, sessionId, dateKey);
+    const used = await this.store.get(bucketKey, "messages");
+    const remaining = Math.max(0, sessionMessageLimit - used);
+    const now = new Date();
+    const resetAt = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
+
+    return {
+      sessionId,
+      allowed: used < sessionMessageLimit,
+      remaining,
+      limit: sessionMessageLimit,
+      used,
+      resetAt,
+    };
+  }
+
   // ─── Billing Cycle Reset ──────────────────────────────────────────────
 
   async resetUsage(agentId: string): Promise<void> {
@@ -239,6 +329,10 @@ export class UsageMeter {
 
   private getBucketKey(agentId: string, date: string): string {
     return `usage:${agentId}:${date}`;
+  }
+
+  private getSessionBucketKey(agentId: string, sessionId: string, date: string): string {
+    return `usage:${agentId}:session:${sessionId}:${date}`;
   }
 
   private getDateKey(date: Date = new Date()): string {

--- a/packages/plugin-sdk/README.md
+++ b/packages/plugin-sdk/README.md
@@ -12,7 +12,7 @@ export default definePlugin({
   version: "1.0.0",
   description: "My custom Karna plugin",
 
-  async activate(ctx: PluginContext) {
+  async register(ctx: PluginContext) {
     // Register a custom tool
     ctx.registerTool({
       name: "my_tool",
@@ -28,13 +28,13 @@ export default definePlugin({
     ctx.registerSkill({
       name: "my-skill",
       triggers: [{ type: "command", value: "/myskill" }],
-      async execute(action, input) {
-        return { output: "Skill executed!", success: true };
+      async handler(context) {
+        return { response: `Skill executed for ${context.input}`, success: true };
       },
     });
   },
 
-  async deactivate() {
+  async unregister() {
     // Cleanup
   },
 });
@@ -57,6 +57,14 @@ Register custom messaging channel adapters.
 2. Add `karna-plugin` keyword to package.json
 3. Publish to npm: `npm publish`
 4. Users install via: `karna marketplace install your-plugin`
+
+## Included Example
+
+See [`examples/echo-plugin.ts`](./examples/echo-plugin.ts) for a minimal plugin that:
+- registers a low-risk tool
+- registers a command-triggered skill
+- logs registration through the plugin context
+- works as a smoke-test target for the SDK
 
 ## API Reference
 

--- a/packages/plugin-sdk/examples/echo-plugin.ts
+++ b/packages/plugin-sdk/examples/echo-plugin.ts
@@ -1,0 +1,51 @@
+import { definePlugin, defineTool, defineSkill, type PluginContext } from "../src/index.js";
+
+export function registerEchoPlugin(context: PluginContext): void {
+  context.registerTool(
+    defineTool({
+      name: "echo_text",
+      description: "Echo back a short text payload for plugin smoke tests.",
+      riskLevel: "low",
+      parameters: {
+        type: "object",
+        properties: {
+          text: { type: "string", description: "Text to echo back" },
+        },
+        required: ["text"],
+        additionalProperties: false,
+      },
+      async execute(input) {
+        return {
+          output: { echoed: String(input.text ?? "") },
+          isError: false,
+          durationMs: 0,
+        };
+      },
+    }),
+  );
+
+  context.registerSkill(
+    defineSkill({
+      name: "echo-helper",
+      description: "Responds with a short echo via the plugin SDK.",
+      triggers: [{ type: "command", value: "/echo", description: "Echo helper command" }],
+      async handler(skillContext) {
+        return {
+          success: true,
+          response: `Echo: ${skillContext.input}`,
+          data: { source: "echo-plugin" },
+        };
+      },
+    }),
+  );
+}
+
+export default definePlugin({
+  name: "echo-plugin",
+  version: "0.1.0",
+  description: "Minimal example plugin for end-to-end SDK registration tests.",
+  async register(context) {
+    registerEchoPlugin(context);
+    context.getLogger().info("Echo plugin registered");
+  },
+});

--- a/tests/agent/failover-route.test.ts
+++ b/tests/agent/failover-route.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { buildFailoverChain, clearProviderCache } from "../../agent/src/models/router.js";
+
+describe("buildFailoverChain", () => {
+  beforeEach(() => {
+    clearProviderCache();
+  });
+
+  it("builds a primary route plus fallback models", () => {
+    const chain = buildFailoverChain("Search the web, write files, and deploy the project");
+    expect(chain.primary.model).toBeTruthy();
+    expect(chain.fallbacks.length).toBeGreaterThan(0);
+    expect(chain.fallbacks[0]?.model).not.toBe(chain.primary.model);
+  });
+
+  it("deduplicates custom fallback models", () => {
+    const chain = buildFailoverChain("Hi there", undefined, [
+      "claude-haiku-4-20250514",
+      "claude-haiku-4-20250514",
+      "gpt-4o-mini",
+    ]);
+    const models = chain.fallbacks.map((item) => item.model);
+    expect(new Set(models).size).toBe(models.length);
+  });
+});

--- a/tests/agent/plugin-sdk-example.test.ts
+++ b/tests/agent/plugin-sdk-example.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from "vitest";
+import echoPlugin, { registerEchoPlugin } from "../../packages/plugin-sdk/examples/echo-plugin.js";
+
+describe("Plugin SDK example", () => {
+  it("registers an example tool and skill", () => {
+    const registerTool = vi.fn();
+    const registerSkill = vi.fn();
+
+    registerEchoPlugin({
+      registerTool,
+      registerSkill,
+      registerChannel: vi.fn(),
+      getConfig: () => ({}),
+      getLogger: () => ({ info: vi.fn() }) as any,
+    });
+
+    expect(registerTool).toHaveBeenCalledTimes(1);
+    expect(registerSkill).toHaveBeenCalledTimes(1);
+  });
+
+  it("exports a valid plugin definition", async () => {
+    expect(echoPlugin.name).toBe("echo-plugin");
+    expect(typeof echoPlugin.register).toBe("function");
+  });
+});

--- a/tests/agent/usage-meter.test.ts
+++ b/tests/agent/usage-meter.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { UsageMeter, InMemoryUsageStore } from "../../packages/payments/src/usage.js";
+
+describe("UsageMeter session limits", () => {
+  it("tracks per-session message counts separately from monthly usage", async () => {
+    const meter = new UsageMeter(new InMemoryUsageStore());
+
+    await meter.trackSessionMessage("agent-1", "session-a", "web");
+    await meter.trackSessionMessage("agent-1", "session-a", "web");
+    await meter.trackSessionMessage("agent-1", "session-b", "web");
+
+    const usage = await meter.getSessionUsage("agent-1", "session-a");
+    expect(usage.totalMessages).toBe(2);
+  });
+
+  it("enforces configurable per-session message limits", async () => {
+    const meter = new UsageMeter(new InMemoryUsageStore());
+    await meter.trackSessionMessage("agent-1", "session-a", "web");
+    await meter.trackSessionMessage("agent-1", "session-a", "web");
+
+    const result = await meter.checkSessionLimits("agent-1", "session-a", 2);
+    expect(result.allowed).toBe(false);
+    expect(result.used).toBe(2);
+    expect(result.remaining).toBe(0);
+  });
+});

--- a/tests/gateway/docker-compose.test.ts
+++ b/tests/gateway/docker-compose.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = "/tmp/karna-user";
+
+describe("docker-compose local development", () => {
+  it("defines gateway bind mounts for hot reload", () => {
+    const src = readFileSync(join(ROOT, "docker-compose.yml"), "utf-8");
+    expect(src).toMatch(/\.\/gateway:\/app\/gateway/);
+    expect(src).toMatch(/\.\/agent:\/app\/agent/);
+    expect(src).toMatch(/\.\/packages:\/app\/packages/);
+  });
+
+  it("defines health checks for critical services", () => {
+    const src = readFileSync(join(ROOT, "docker-compose.yml"), "utf-8");
+    expect(src).toMatch(/gateway:[\s\S]*healthcheck:/);
+    expect(src).toMatch(/supabase-auth:[\s\S]*healthcheck:/);
+    expect(src).toMatch(/redis:[\s\S]*healthcheck:/);
+  });
+});


### PR DESCRIPTION
## Summary
- add per-session usage tracking and configurable session limit checks
- add failover-chain construction on top of the model router
- add a real plugin SDK example plus smoke-test coverage
- improve docker-compose local-dev ergonomics with bind mounts and health checks, plus compose coverage tests

## Testing
- targeted vitest slices could not run here because local node dependencies are not installed in this clone

Closes #4
Closes #5
Closes #7
Closes #9