### PR TITLE
feat(gateway): add memory routes and protocol coverage

### DIFF
--- a/agent/package.json
+++ b/agent/package.json
@@ -15,6 +15,7 @@
     "./context/builder.js": "./dist/context/builder.js",
     "./context/system-prompt.js": "./dist/context/system-prompt.js",
     "./memory/store.js": "./dist/memory/store.js",
+    "./memory/supabase-backend.js": "./dist/memory/supabase-backend.js",
     "./memory/embedder.js": "./dist/memory/embedder.js",
     "./voice/index.js": "./dist/voice/index.js",
     "./orchestration/orchestrator.js": "./dist/orchestration/orchestrator.js",
@@ -31,7 +32,9 @@
   },
   "dependencies": {
     "@karna/shared": "workspace:*",
+    "@karna/supabase": "workspace:*",
     "@anthropic-ai/sdk": "^0.39.0",
+    "@supabase/supabase-js": "^2.49.8",
     "openai": "^4.75.0",
     "zod": "^3.23.0",
     "pino": "^9.0.0",

--- a/agent/src/memory/supabase-backend.ts
+++ b/agent/src/memory/supabase-backend.ts
@@ -1,0 +1,142 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import pino from "pino";
+import type { MemoryEntry } from "@karna/shared/types/memory.js";
+import { searchMemories } from "@karna/supabase";
+import type { MemoryBackend, MemorySearchParams, SaveMemoryInput, ScoredMemory } from "./store.js";
+
+const logger = pino({ name: "supabase-memory-backend" });
+
+function mapPriorityToImportance(priority?: SaveMemoryInput["priority"]): number {
+  switch (priority) {
+    case "critical":
+      return 1.0;
+    case "high":
+      return 0.85;
+    case "low":
+      return 0.25;
+    default:
+      return 0.5;
+  }
+}
+
+function mapImportanceToPriority(importance?: number): MemoryEntry["priority"] {
+  if ((importance ?? 0.5) >= 0.95) return "critical";
+  if ((importance ?? 0.5) >= 0.75) return "high";
+  if ((importance ?? 0.5) <= 0.3) return "low";
+  return "normal";
+}
+
+function mapRowToEntry(row: Record<string, unknown>): MemoryEntry {
+  const createdAt = Date.parse(String(row["created_at"] ?? Date.now()));
+  const updatedAt = Date.parse(String(row["updated_at"] ?? row["created_at"] ?? Date.now()));
+  const accessedAt = Date.parse(String(row["accessed_at"] ?? row["last_accessed_at"] ?? row["created_at"] ?? Date.now()));
+  const expiresAtRaw = row["expires_at"];
+  const expiresAt = expiresAtRaw ? Date.parse(String(expiresAtRaw)) : undefined;
+
+  return {
+    id: String(row["id"]),
+    sessionId: row["source_session_id"] ? String(row["source_session_id"]) : undefined,
+    userId: undefined,
+    content: String(row["content"] ?? ""),
+    summary: undefined,
+    embedding: Array.isArray(row["embedding"]) ? (row["embedding"] as number[]) : undefined,
+    source: "conversation",
+    priority: mapImportanceToPriority(typeof row["importance"] === "number" ? row["importance"] : undefined),
+    tags: [],
+    category: row["category"] ? String(row["category"]) : undefined,
+    relatedMessageIds: [],
+    relatedMemoryIds: [],
+    createdAt: Number.isNaN(createdAt) ? Date.now() : createdAt,
+    updatedAt: Number.isNaN(updatedAt) ? Date.now() : updatedAt,
+    accessedAt: Number.isNaN(accessedAt) ? Date.now() : accessedAt,
+    expiresAt: expiresAt !== undefined && !Number.isNaN(expiresAt) ? expiresAt : undefined,
+    accessCount: Number(row["access_count"] ?? 0),
+    decayFactor: Number(row["decay_factor"] ?? 1),
+  };
+}
+
+export class SupabaseMemoryBackend implements MemoryBackend {
+  constructor(private readonly client: SupabaseClient) {}
+
+  async save(input: SaveMemoryInput): Promise<MemoryEntry> {
+    const payload = {
+      agent_id: input.agentId,
+      content: input.content,
+      category: input.category ?? null,
+      source_session_id: input.sessionId ?? null,
+      embedding: input.embedding ?? null,
+      importance: mapPriorityToImportance(input.priority),
+      expires_at: input.expiresAt ? new Date(input.expiresAt).toISOString() : null,
+    };
+
+    const { data, error } = await this.client
+      .from("memories")
+      .insert(payload)
+      .select("*")
+      .single();
+
+    if (error || !data) {
+      logger.error({ error, agentId: input.agentId }, "Failed to save memory to Supabase");
+      throw error ?? new Error("Failed to save memory");
+    }
+
+    return mapRowToEntry(data as Record<string, unknown>);
+  }
+
+  async search(params: MemorySearchParams): Promise<ScoredMemory[]> {
+    const rows = await searchMemories(this.client, {
+      agentId: params.agentId,
+      embedding: params.embedding,
+      matchCount: params.limit,
+      matchThreshold: params.minRelevance,
+      category: params.category,
+    });
+
+    return (rows ?? []).map((row: Record<string, unknown>) => {
+      const entry = mapRowToEntry(row);
+      return {
+        ...entry,
+        score: Number(row["similarity"] ?? row["score"] ?? 0),
+      };
+    });
+  }
+
+  async getById(id: string): Promise<MemoryEntry | null> {
+    const { data, error } = await this.client
+      .from("memories")
+      .select("*")
+      .eq("id", id)
+      .maybeSingle();
+
+    if (error) throw error;
+    if (!data) return null;
+    return mapRowToEntry(data as Record<string, unknown>);
+  }
+
+  async delete(id: string): Promise<boolean> {
+    const { error, count } = await this.client
+      .from("memories")
+      .delete({ count: "exact" })
+      .eq("id", id);
+
+    if (error) throw error;
+    return (count ?? 0) > 0;
+  }
+
+  async updateAccessedAt(id: string): Promise<void> {
+    const current = await this.getById(id);
+    if (!current) return;
+
+    const { error } = await this.client
+      .from("memories")
+      .update({
+        accessed_at: new Date().toISOString(),
+        access_count: current.accessCount + 1,
+      })
+      .eq("id", id);
+
+    if (error) {
+      logger.warn({ error, id }, "Failed to update memory access metadata");
+    }
+  }
+}

--- a/agent/src/models/router.ts
+++ b/agent/src/models/router.ts
@@ -28,6 +28,17 @@ export interface RouteResult {
   complexity: ComplexityTier;
 }
 
+export interface ModelTarget {
+  provider: ModelProvider;
+  model: string;
+}
+
+export interface FailoverRoute {
+  primary: ModelTarget;
+  fallbacks: ModelTarget[];
+  complexity: ComplexityTier;
+}
+
 export type ComplexityTier = "simple" | "moderate" | "complex";
 
 // ─── Complexity Thresholds ──────────────────────────────────────────────────
@@ -45,6 +56,12 @@ const DEFAULT_MODELS: Record<ComplexityTier, string> = {
   simple: "claude-haiku-4-20250514",
   moderate: "claude-sonnet-4-20250514",
   complex: "claude-sonnet-4-20250514",
+};
+
+const DEFAULT_FALLBACK_MODELS: Record<ComplexityTier, string[]> = {
+  simple: ["gpt-4o-mini", "claude-sonnet-4-20250514"],
+  moderate: ["gpt-4o", "claude-haiku-4-20250514"],
+  complex: ["gpt-4o", "claude-opus-4-20250514"],
 };
 
 // ─── Provider Cache ─────────────────────────────────────────────────────────
@@ -152,6 +169,33 @@ export function routeModel(message: string, agent?: AgentConfig): RouteResult {
   );
 
   return { provider, model, complexity };
+}
+
+export function buildFailoverChain(
+  message: string,
+  agent?: AgentConfig,
+  fallbackModels?: string[],
+): FailoverRoute {
+  const primary = routeModel(message, agent);
+  const desiredFallbacks = fallbackModels ?? DEFAULT_FALLBACK_MODELS[primary.complexity];
+  const seen = new Set([primary.model]);
+  const fallbacks: ModelTarget[] = [];
+
+  for (const model of desiredFallbacks) {
+    if (seen.has(model)) continue;
+    seen.add(model);
+    const providerName = inferProvider(model);
+    fallbacks.push({
+      model,
+      provider: getProvider(providerName),
+    });
+  }
+
+  return {
+    primary: { provider: primary.provider, model: primary.model },
+    fallbacks,
+    complexity: primary.complexity,
+  };
 }
 
 /**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,11 +19,21 @@ services:
       - REDIS_URL=redis://redis:6379
     volumes:
       - karna-data:/root/.karna
+      - ./gateway:/app/gateway
+      - ./agent:/app/agent
+      - ./packages:/app/packages
     depends_on:
       supabase-db:
         condition: service_healthy
       redis:
         condition: service_healthy
+      supabase-auth:
+        condition: service_started
+    healthcheck:
+      test: ["CMD-SHELL", "node -e \"fetch('http://127.0.0.1:18789/health').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))\""]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     restart: unless-stopped
 
   supabase-db:
@@ -74,6 +84,11 @@ services:
     depends_on:
       supabase-db:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget --spider -q http://127.0.0.1:9999/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     restart: unless-stopped
 
   redis:

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -11,6 +11,10 @@ import { loadConfig } from "./config/loader.js";
 import { getSystemHealth, setConnectionCounter, setSessionCounter } from "./health/status.js";
 import { MetricsCollector } from "./health/metrics.js";
 import { validateGatewayEnv } from "./config/validate-env.js";
+import { MemoryStore, InMemoryBackend } from "@karna/agent/memory/store.js";
+import { SupabaseMemoryBackend } from "@karna/agent/memory/supabase-backend.js";
+import { createSupabaseClient } from "@karna/supabase";
+import { registerMemoryRoutes } from "./routes/memory.js";
 
 // ─── Logger ─────────────────────────────────────────────────────────────────
 
@@ -46,6 +50,20 @@ async function main(): Promise<void> {
   }
 
   const metricsCollector = new MetricsCollector();
+  let memoryStore = new MemoryStore(new InMemoryBackend());
+
+  if (
+    config.memory.enabled &&
+    (config.memory.backend === "supabase" || process.env["SUPABASE_URL"])
+  ) {
+    try {
+      const supabase = createSupabaseClient();
+      memoryStore = new MemoryStore(new SupabaseMemoryBackend(supabase));
+      logger.info("Memory store configured with Supabase pgvector backend");
+    } catch (error) {
+      logger.warn({ error: String(error) }, "Falling back to in-memory memory store");
+    }
+  }
 
   // Connected clients registry
   const connectedClients = new Map<string, ConnectedClient>();
@@ -176,6 +194,8 @@ async function main(): Promise<void> {
       ),
     });
   });
+
+  registerMemoryRoutes(server, memoryStore);
 
   // ─── WebSocket Route ────────────────────────────────────────────────────
 

--- a/gateway/src/protocol/handler.ts
+++ b/gateway/src/protocol/handler.ts
@@ -19,6 +19,7 @@ import { handleVoiceStart, handleVoiceAudioChunk, handleVoiceEnd } from "../voic
 import { appendToTranscript, readTranscript } from "../session/store.js";
 import { Orchestrator } from "@karna/agent/orchestration/orchestrator.js";
 import type { AgentDefinition, DelegationRecord } from "@karna/shared/types/orchestration.js";
+import type { Session } from "@karna/shared/types/session.js";
 
 const logger = pino({ name: "message-handler" });
 
@@ -68,11 +69,58 @@ const DEFAULT_AGENTS: AgentDefinition[] = [
   },
 ];
 
-let orchestrator: Orchestrator | null = null;
+interface OrchestratorLike {
+  activeAgentCount: number;
+  init(): Promise<void>;
+  setStreamCallback(callback: StreamCallback): void;
+  setApprovalCallback(
+    callback: (request: { toolCallId: string }) => Promise<{
+      toolCallId: string;
+      approved: boolean;
+      reason?: string;
+      respondedAt: number;
+    }>,
+  ): void;
+  setDelegationCallback(callback: (record: DelegationRecord) => void): void;
+  handleMessage(
+    session: Session,
+    content: string,
+    history: unknown[],
+  ): Promise<{
+    success: boolean;
+    response: string;
+    error?: string;
+    totalTokens: { inputTokens: number; outputTokens: number };
+    agentId: string;
+    delegations: DelegationRecord[];
+  }>;
+}
+
+let orchestrator: OrchestratorLike | null = null;
+let orchestratorFactory: (() => Promise<OrchestratorLike>) | null = null;
 const pendingApprovals = new Map<string, { resolve: (approved: boolean) => void; timer: ReturnType<typeof setTimeout> }>();
 
-async function getOrCreateOrchestrator(): Promise<Orchestrator> {
+export function setOrchestratorFactoryForTests(factory: (() => Promise<OrchestratorLike>) | null): void {
+  orchestratorFactory = factory;
+  orchestrator = null;
+}
+
+export function resetProtocolTestState(): void {
+  for (const pending of pendingApprovals.values()) {
+    clearTimeout(pending.timer);
+  }
+  pendingApprovals.clear();
+  orchestrator = null;
+  orchestratorFactory = null;
+}
+
+async function getOrCreateOrchestrator(): Promise<OrchestratorLike> {
   if (orchestrator) return orchestrator;
+
+  if (orchestratorFactory) {
+    orchestrator = await orchestratorFactory();
+    return orchestrator;
+  }
 
   orchestrator = new Orchestrator({
     agents: DEFAULT_AGENTS,

--- a/gateway/src/routes/memory.ts
+++ b/gateway/src/routes/memory.ts
@@ -1,0 +1,91 @@
+import type { FastifyInstance } from "fastify";
+import {
+  CreateMemoryInputSchema,
+  type CreateMemoryInput,
+} from "@karna/shared/types/memory.js";
+import type { MemoryStore } from "@karna/agent/memory/store.js";
+
+interface MemorySearchBody {
+  agentId: string;
+  embedding: number[];
+  limit?: number;
+  minRelevance?: number;
+  category?: string;
+  tags?: string[];
+  source?: CreateMemoryInput["source"];
+}
+
+interface MemoryCreateBody extends CreateMemoryInput {
+  agentId: string;
+}
+
+export function registerMemoryRoutes(app: FastifyInstance, memoryStore: MemoryStore): void {
+  app.post<{ Body: MemoryCreateBody }>("/api/memory", async (request, reply) => {
+    const body = request.body;
+    const parsed = CreateMemoryInputSchema.safeParse(body);
+
+    if (!parsed.success || !body?.agentId) {
+      return reply.status(400).send({
+        error: "Invalid memory payload",
+        details: parsed.success ? ["agentId is required"] : parsed.error.flatten(),
+      });
+    }
+
+    const entry = await memoryStore.save({
+      agentId: body.agentId,
+      content: parsed.data.content,
+      summary: parsed.data.summary,
+      source: parsed.data.source,
+      priority: parsed.data.priority,
+      category: parsed.data.category,
+      tags: parsed.data.tags,
+      sessionId: parsed.data.sessionId,
+      userId: parsed.data.userId,
+      relatedMessageIds: parsed.data.relatedMessageIds,
+      expiresAt: parsed.data.expiresAt,
+    });
+
+    return reply.status(201).send({ memory: entry });
+  });
+
+  app.post<{ Body: MemorySearchBody }>("/api/memory/search", async (request, reply) => {
+    const body = request.body;
+    if (!body?.agentId || !Array.isArray(body.embedding) || body.embedding.length === 0) {
+      return reply.status(400).send({
+        error: "agentId and a non-empty embedding array are required",
+      });
+    }
+
+    const entries = await memoryStore.search({
+      agentId: body.agentId,
+      embedding: body.embedding,
+      limit: body.limit,
+      minRelevance: body.minRelevance,
+      category: body.category,
+      tags: body.tags,
+      source: body.source,
+    });
+
+    return {
+      entries,
+      total: entries.length,
+      hasMore: false,
+    };
+  });
+
+  app.get<{ Params: { id: string } }>("/api/memory/:id", async (request, reply) => {
+    const entry = await memoryStore.getById(request.params.id);
+    if (!entry) {
+      return reply.status(404).send({ error: "Memory not found" });
+    }
+    return { memory: entry };
+  });
+
+  app.delete<{ Params: { id: string } }>("/api/memory/:id", async (request, reply) => {
+    const deleted = await memoryStore.delete(request.params.id);
+    if (!deleted) {
+      return reply.status(404).send({ error: "Memory not found" });
+    }
+    return reply.status(204).send();
+  });
+}

--- a/packages/payments/src/index.ts
+++ b/packages/payments/src/index.ts
@@ -55,5 +55,6 @@ export {
   type UsageRecord,
   type UsageReport,
   type LimitCheckResult,
+  type SessionLimitCheckResult,
   type UsageStore,
 } from "./usage.js";

--- a/packages/payments/src/usage.ts
+++ b/packages/payments/src/usage.ts
@@ -42,6 +42,10 @@ export interface LimitCheckResult {
   resetAt: Date;
 }
 
+export interface SessionLimitCheckResult extends LimitCheckResult {
+  sessionId: string;
+}
+
 export interface UsageStore {
   increment(key: string, field: string, amount: number): Promise<number>;
   get(key: string, field: string): Promise<number>;
@@ -123,6 +127,19 @@ export class UsageMeter {
     return count;
   }
 
+  async trackSessionMessage(agentId: string, sessionId: string, channel: string): Promise<number> {
+    if (!sessionId) throw new Error("Session ID is required");
+
+    const dateKey = this.getDateKey();
+    const bucketKey = this.getSessionBucketKey(agentId, sessionId, dateKey);
+
+    const count = await this.store.increment(bucketKey, "messages", 1);
+    await this.store.increment(bucketKey, `messages:${channel}`, 1);
+
+    logger.debug({ agentId, sessionId, channel, totalMessages: count }, "Session message tracked");
+    return count;
+  }
+
   async trackTokens(agentId: string, inputTokens: number, outputTokens: number): Promise<void> {
     if (!agentId) throw new Error("Agent ID is required");
     if (inputTokens < 0 || outputTokens < 0) throw new Error("Token counts must be non-negative");
@@ -189,6 +206,55 @@ export class UsageMeter {
     };
   }
 
+  async getSessionUsage(agentId: string, sessionId: string, period: UsagePeriod = "daily"): Promise<UsageReport> {
+    if (!agentId) throw new Error("Agent ID is required");
+    if (!sessionId) throw new Error("Session ID is required");
+
+    const now = new Date();
+    const dates = period === "daily" ? [this.getDateKey(now)] : this.getMonthDates(now);
+    const daily: UsageRecord[] = [];
+    let totalMessages = 0;
+    let totalTokensIn = 0;
+    let totalTokensOut = 0;
+
+    for (const date of dates) {
+      const bucketKey = this.getSessionBucketKey(agentId, sessionId, date);
+      const data = await this.store.getAll(bucketKey);
+      const messages = data["messages"] ?? 0;
+      const tokensIn = data["tokens_in"] ?? 0;
+      const tokensOut = data["tokens_out"] ?? 0;
+
+      totalMessages += messages;
+      totalTokensIn += tokensIn;
+      totalTokensOut += tokensOut;
+
+      if (messages > 0 || tokensIn > 0 || tokensOut > 0) {
+        daily.push({
+          agentId,
+          channel: "session",
+          messages,
+          tokensIn,
+          tokensOut,
+          date,
+        });
+      }
+    }
+
+    const costCents = Math.ceil((totalTokensIn * 0.3 + totalTokensOut * 1.5) / 100_000);
+
+    return {
+      agentId,
+      period,
+      startDate: dates[0] ?? this.getDateKey(now),
+      endDate: dates[dates.length - 1] ?? this.getDateKey(now),
+      totalMessages,
+      totalTokensIn,
+      totalTokensOut,
+      costCents,
+      daily,
+    };
+  }
+
   // ─── Limit Checks ──────────────────────────────────────────────────────
 
   async checkLimits(agentId: string, plan: PlanId): Promise<LimitCheckResult> {
@@ -219,6 +285,30 @@ export class UsageMeter {
     return { allowed, remaining, limit, used: totalMessages, resetAt };
   }
 
+  async checkSessionLimits(
+    agentId: string,
+    sessionId: string,
+    sessionMessageLimit: number,
+  ): Promise<SessionLimitCheckResult> {
+    if (!sessionId) throw new Error("Session ID is required");
+
+    const dateKey = this.getDateKey();
+    const bucketKey = this.getSessionBucketKey(agentId, sessionId, dateKey);
+    const used = await this.store.get(bucketKey, "messages");
+    const remaining = Math.max(0, sessionMessageLimit - used);
+    const now = new Date();
+    const resetAt = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
+
+    return {
+      sessionId,
+      allowed: used < sessionMessageLimit,
+      remaining,
+      limit: sessionMessageLimit,
+      used,
+      resetAt,
+    };
+  }
+
   // ─── Billing Cycle Reset ──────────────────────────────────────────────
 
   async resetUsage(agentId: string): Promise<void> {
@@ -239,6 +329,10 @@ export class UsageMeter {
 
   private getBucketKey(agentId: string, date: string): string {
     return `usage:${agentId}:${date}`;
+  }
+
+  private getSessionBucketKey(agentId: string, sessionId: string, date: string): string {
+    return `usage:${agentId}:session:${sessionId}:${date}`;
   }
 
   private getDateKey(date: Date = new Date()): string {

--- a/packages/plugin-sdk/README.md
+++ b/packages/plugin-sdk/README.md
@@ -12,7 +12,7 @@ export default definePlugin({
   version: "1.0.0",
   description: "My custom Karna plugin",
 
-  async activate(ctx: PluginContext) {
+  async register(ctx: PluginContext) {
     // Register a custom tool
     ctx.registerTool({
       name: "my_tool",
@@ -28,13 +28,13 @@ export default definePlugin({
     ctx.registerSkill({
       name: "my-skill",
       triggers: [{ type: "command", value: "/myskill" }],
-      async execute(action, input) {
-        return { output: "Skill executed!", success: true };
+      async handler(context) {
+        return { response: `Skill executed for ${context.input}`, success: true };
       },
     });
   },
 
-  async deactivate() {
+  async unregister() {
     // Cleanup
   },
 });
@@ -57,6 +57,14 @@ Register custom messaging channel adapters.
 2. Add `karna-plugin` keyword to package.json
 3. Publish to npm: `npm publish`
 4. Users install via: `karna marketplace install your-plugin`
+
+## Included Example
+
+See [`examples/echo-plugin.ts`](./examples/echo-plugin.ts) for a minimal plugin that:
+- registers a low-risk tool
+- registers a command-triggered skill
+- logs registration through the plugin context
+- works as a smoke-test target for the SDK
 
 ## API Reference
 

--- a/packages/plugin-sdk/examples/echo-plugin.ts
+++ b/packages/plugin-sdk/examples/echo-plugin.ts
@@ -1,0 +1,51 @@
+import { definePlugin, defineTool, defineSkill, type PluginContext } from "../src/index.js";
+
+export function registerEchoPlugin(context: PluginContext): void {
+  context.registerTool(
+    defineTool({
+      name: "echo_text",
+      description: "Echo back a short text payload for plugin smoke tests.",
+      riskLevel: "low",
+      parameters: {
+        type: "object",
+        properties: {
+          text: { type: "string", description: "Text to echo back" },
+        },
+        required: ["text"],
+        additionalProperties: false,
+      },
+      async execute(input) {
+        return {
+          output: { echoed: String(input.text ?? "") },
+          isError: false,
+          durationMs: 0,
+        };
+      },
+    }),
+  );
+
+  context.registerSkill(
+    defineSkill({
+      name: "echo-helper",
+      description: "Responds with a short echo via the plugin SDK.",
+      triggers: [{ type: "command", value: "/echo", description: "Echo helper command" }],
+      async handler(skillContext) {
+        return {
+          success: true,
+          response: `Echo: ${skillContext.input}`,
+          data: { source: "echo-plugin" },
+        };
+      },
+    }),
+  );
+}
+
+export default definePlugin({
+  name: "echo-plugin",
+  version: "0.1.0",
+  description: "Minimal example plugin for end-to-end SDK registration tests.",
+  async register(context) {
+    registerEchoPlugin(context);
+    context.getLogger().info("Echo plugin registered");
+  },
+});

--- a/packages/shared/src/types/config.ts
+++ b/packages/shared/src/types/config.ts
@@ -95,7 +95,7 @@ export type ChannelConfig = z.infer<typeof ChannelConfigSchema>;
 
 export const MemoryConfigSchema = z.object({
   enabled: z.boolean().default(true),
-  backend: z.enum(["sqlite", "postgres", "redis"]).default("sqlite"),
+  backend: z.enum(["sqlite", "postgres", "redis", "supabase"]).default("sqlite"),
   connectionString: z.string().optional(),
   maxEntriesPerSession: z.number().int().positive().default(1000),
   defaultTtlMs: z.number().int().positive().optional(),

--- a/tests/agent/failover-route.test.ts
+++ b/tests/agent/failover-route.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { buildFailoverChain, clearProviderCache } from "../../agent/src/models/router.js";
+
+describe("buildFailoverChain", () => {
+  beforeEach(() => {
+    clearProviderCache();
+  });
+
+  it("builds a primary route plus fallback models", () => {
+    const chain = buildFailoverChain("Search the web, write files, and deploy the project");
+    expect(chain.primary.model).toBeTruthy();
+    expect(chain.fallbacks.length).toBeGreaterThan(0);
+    expect(chain.fallbacks[0]?.model).not.toBe(chain.primary.model);
+  });
+
+  it("deduplicates custom fallback models", () => {
+    const chain = buildFailoverChain("Hi there", undefined, [
+      "claude-haiku-4-20250514",
+      "claude-haiku-4-20250514",
+      "gpt-4o-mini",
+    ]);
+    const models = chain.fallbacks.map((item) => item.model);
+    expect(new Set(models).size).toBe(models.length);
+  });
+});

--- a/tests/agent/plugin-sdk-example.test.ts
+++ b/tests/agent/plugin-sdk-example.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from "vitest";
+import echoPlugin, { registerEchoPlugin } from "../../packages/plugin-sdk/examples/echo-plugin.js";
+
+describe("Plugin SDK example", () => {
+  it("registers an example tool and skill", () => {
+    const registerTool = vi.fn();
+    const registerSkill = vi.fn();
+
+    registerEchoPlugin({
+      registerTool,
+      registerSkill,
+      registerChannel: vi.fn(),
+      getConfig: () => ({}),
+      getLogger: () => ({ info: vi.fn() }) as any,
+    });
+
+    expect(registerTool).toHaveBeenCalledTimes(1);
+    expect(registerSkill).toHaveBeenCalledTimes(1);
+  });
+
+  it("exports a valid plugin definition", async () => {
+    expect(echoPlugin.name).toBe("echo-plugin");
+    expect(typeof echoPlugin.register).toBe("function");
+  });
+});

--- a/tests/agent/supabase-memory-backend.test.ts
+++ b/tests/agent/supabase-memory-backend.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { SupabaseMemoryBackend } from "../../agent/src/memory/supabase-backend.js";
+
+function createClient(overrides?: {
+  insertRow?: Record<string, unknown>;
+  getRow?: Record<string, unknown> | null;
+  searchRows?: Record<string, unknown>[];
+}) {
+  const insertRow = overrides?.insertRow ?? {
+    id: "mem-1",
+    content: "Remember this",
+    created_at: "2026-04-20T00:00:00.000Z",
+    updated_at: "2026-04-20T00:00:00.000Z",
+    accessed_at: "2026-04-20T00:00:00.000Z",
+    access_count: 0,
+    decay_factor: 1,
+    source_session_id: "session-1",
+    category: "preference",
+    importance: 0.85,
+  };
+  const getRow = overrides?.getRow ?? insertRow;
+  const searchRows = overrides?.searchRows ?? [
+    {
+      ...insertRow,
+      similarity: 0.91,
+    },
+  ];
+
+  const eqSingle = vi.fn().mockResolvedValue({ data: getRow, error: null });
+  const updateEq = vi.fn().mockResolvedValue({ error: null });
+  const deleteEq = vi.fn().mockResolvedValue({ error: null, count: 1 });
+  let lastUpdatePayload: Record<string, unknown> | null = null;
+
+  const client = {
+    from: vi.fn((_table: string) => ({
+      insert: vi.fn((_payload: unknown) => ({
+        select: vi.fn(() => ({
+          single: vi.fn().mockResolvedValue({ data: insertRow, error: null }),
+        })),
+      })),
+      select: vi.fn((_cols?: string) => ({
+        eq: vi.fn((_col: string, _val: string) => ({
+          maybeSingle: eqSingle,
+        })),
+      })),
+      delete: vi.fn((_opts?: unknown) => ({
+        eq: deleteEq,
+      })),
+      update: vi.fn((payload: unknown) => {
+        lastUpdatePayload = payload as Record<string, unknown>;
+        return ({
+        eq: updateEq,
+        });
+      }),
+    })),
+    rpc: vi.fn().mockResolvedValue({ data: searchRows, error: null }),
+  };
+
+  return { client, eqSingle, updateEq, getLastUpdatePayload: () => lastUpdatePayload };
+}
+
+describe("SupabaseMemoryBackend", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("saves and maps memory rows into MemoryEntry shape", async () => {
+    const { client } = createClient();
+    const backend = new SupabaseMemoryBackend(client as never);
+
+    const entry = await backend.save({
+      agentId: "agent-1",
+      content: "Remember this",
+      source: "conversation",
+      priority: "high",
+      sessionId: "session-1",
+      category: "preference",
+    });
+
+    expect(entry.id).toBe("mem-1");
+    expect(entry.sessionId).toBe("session-1");
+    expect(entry.priority).toBe("high");
+    expect(entry.source).toBe("conversation");
+    expect(entry.category).toBe("preference");
+  });
+
+  it("searches memories through the pgvector RPC and preserves scores", async () => {
+    const { client } = createClient();
+    const backend = new SupabaseMemoryBackend(client as never);
+
+    const results = await backend.search({
+      agentId: "agent-1",
+      embedding: [0.1, 0.2, 0.3],
+      limit: 5,
+      minRelevance: 0.8,
+      category: "preference",
+    });
+
+    expect(client.rpc).toHaveBeenCalled();
+    expect(results).toHaveLength(1);
+    expect(results[0]?.score).toBe(0.91);
+  });
+
+  it("increments access_count when updating access metadata", async () => {
+    const { client, updateEq, getLastUpdatePayload } = createClient({
+      getRow: {
+        id: "mem-1",
+        content: "Remember this",
+        created_at: "2026-04-20T00:00:00.000Z",
+        updated_at: "2026-04-20T00:00:00.000Z",
+        accessed_at: "2026-04-20T00:00:00.000Z",
+        access_count: 4,
+        decay_factor: 1,
+        importance: 0.5,
+      },
+    });
+    const backend = new SupabaseMemoryBackend(client as never);
+
+    await backend.updateAccessedAt("mem-1");
+
+    expect(updateEq).toHaveBeenCalled();
+    expect(getLastUpdatePayload()?.["access_count"]).toBe(5);
+  });
+});

--- a/tests/agent/usage-meter.test.ts
+++ b/tests/agent/usage-meter.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { UsageMeter, InMemoryUsageStore } from "../../packages/payments/src/usage.js";
+
+describe("UsageMeter session limits", () => {
+  it("tracks per-session message counts separately from monthly usage", async () => {
+    const meter = new UsageMeter(new InMemoryUsageStore());
+
+    await meter.trackSessionMessage("agent-1", "session-a", "web");
+    await meter.trackSessionMessage("agent-1", "session-a", "web");
+    await meter.trackSessionMessage("agent-1", "session-b", "web");
+
+    const usage = await meter.getSessionUsage("agent-1", "session-a");
+    expect(usage.totalMessages).toBe(2);
+  });
+
+  it("enforces configurable per-session message limits", async () => {
+    const meter = new UsageMeter(new InMemoryUsageStore());
+    await meter.trackSessionMessage("agent-1", "session-a", "web");
+    await meter.trackSessionMessage("agent-1", "session-a", "web");
+
+    const result = await meter.checkSessionLimits("agent-1", "session-a", 2);
+    expect(result.allowed).toBe(false);
+    expect(result.used).toBe(2);
+    expect(result.remaining).toBe(0);
+  });
+});

--- a/tests/gateway/docker-compose.test.ts
+++ b/tests/gateway/docker-compose.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = "/tmp/karna-user";
+
+describe("docker-compose local development", () => {
+  it("defines gateway bind mounts for hot reload", () => {
+    const src = readFileSync(join(ROOT, "docker-compose.yml"), "utf-8");
+    expect(src).toMatch(/\.\/gateway:\/app\/gateway/);
+    expect(src).toMatch(/\.\/agent:\/app\/agent/);
+    expect(src).toMatch(/\.\/packages:\/app\/packages/);
+  });
+
+  it("defines health checks for critical services", () => {
+    const src = readFileSync(join(ROOT, "docker-compose.yml"), "utf-8");
+    expect(src).toMatch(/gateway:[\s\S]*healthcheck:/);
+    expect(src).toMatch(/supabase-auth:[\s\S]*healthcheck:/);
+    expect(src).toMatch(/redis:[\s\S]*healthcheck:/);
+  });
+});

--- a/tests/gateway/memory-routes.test.ts
+++ b/tests/gateway/memory-routes.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Fastify from "fastify";
+import { MemoryStore, InMemoryBackend } from "../../agent/src/memory/store.js";
+import { registerMemoryRoutes } from "../../gateway/src/routes/memory.js";
+
+describe("memory routes", () => {
+  let app: ReturnType<typeof Fastify>;
+
+  beforeEach(async () => {
+    app = Fastify();
+    registerMemoryRoutes(app, new MemoryStore(new InMemoryBackend()));
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it("creates, retrieves, searches, and deletes memories", async () => {
+    const create = await app.inject({
+      method: "POST",
+      url: "/api/memory",
+      payload: {
+        agentId: "agent-1",
+        content: "User prefers concise answers",
+        source: "conversation",
+        priority: "high",
+        category: "preference",
+        tags: ["preference"],
+      },
+    });
+
+    expect(create.statusCode).toBe(201);
+    const created = create.json().memory;
+    expect(created.content).toContain("concise");
+
+    const get = await app.inject({
+      method: "GET",
+      url: `/api/memory/${created.id}`,
+    });
+    expect(get.statusCode).toBe(200);
+    expect(get.json().memory.id).toBe(created.id);
+
+    const search = await app.inject({
+      method: "POST",
+      url: "/api/memory/search",
+      payload: {
+        agentId: "agent-1",
+        embedding: [0.2, 0.3, 0.4],
+        limit: 5,
+      },
+    });
+    expect(search.statusCode).toBe(200);
+    expect(Array.isArray(search.json().entries)).toBe(true);
+
+    const remove = await app.inject({
+      method: "DELETE",
+      url: `/api/memory/${created.id}`,
+    });
+    expect(remove.statusCode).toBe(204);
+
+    const missing = await app.inject({
+      method: "GET",
+      url: `/api/memory/${created.id}`,
+    });
+    expect(missing.statusCode).toBe(404);
+  });
+
+  it("validates malformed create and search payloads", async () => {
+    const badCreate = await app.inject({
+      method: "POST",
+      url: "/api/memory",
+      payload: {
+        content: "",
+        source: "conversation",
+      },
+    });
+    expect(badCreate.statusCode).toBe(400);
+
+    const badSearch = await app.inject({
+      method: "POST",
+      url: "/api/memory/search",
+      payload: {
+        agentId: "agent-1",
+        embedding: [],
+      },
+    });
+    expect(badSearch.statusCode).toBe(400);
+  });
+});

--- a/tests/gateway/websocket-protocol.test.ts
+++ b/tests/gateway/websocket-protocol.test.ts
@@ -1,0 +1,210 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import { SessionManager } from "../../gateway/src/session/manager.js";
+import {
+  handleMessage,
+  resetProtocolTestState,
+  setOrchestratorFactoryForTests,
+  type ConnectionContext,
+} from "../../gateway/src/protocol/handler.js";
+import { createAuthContext } from "../../gateway/src/protocol/auth.js";
+import { appendToTranscript, readTranscript } from "../../gateway/src/session/store.js";
+
+vi.mock("../../gateway/src/session/store.js", () => ({
+  appendToTranscript: vi.fn().mockResolvedValue(undefined),
+  readTranscript: vi.fn().mockResolvedValue([]),
+}));
+
+function createSocket() {
+  const sent: Record<string, unknown>[] = [];
+  return {
+    OPEN: 1,
+    readyState: 1,
+    sent,
+    send(payload: string) {
+      sent.push(JSON.parse(payload));
+    },
+  };
+}
+
+function createContext(overrides?: Partial<ConnectionContext>): ConnectionContext {
+  const sessionManager = overrides?.sessionManager ?? new SessionManager({ flushIntervalMs: 300_000 });
+  return {
+    ws: overrides?.ws ?? (createSocket() as never),
+    auth: overrides?.auth ?? null,
+    sessionManager,
+    heartbeatScheduler: overrides?.heartbeatScheduler ?? ({ stopAll() {} } as never),
+    connectedClients: overrides?.connectedClients ?? new Map(),
+  };
+}
+
+describe("gateway websocket protocol", () => {
+  const originalNodeEnv = process.env["NODE_ENV"];
+  const originalGatewayToken = process.env["GATEWAY_AUTH_TOKEN"];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetProtocolTestState();
+    delete process.env["GATEWAY_AUTH_TOKEN"];
+    process.env["NODE_ENV"] = "test";
+  });
+
+  afterEach(() => {
+    resetProtocolTestState();
+    if (originalNodeEnv === undefined) delete process.env["NODE_ENV"];
+    else process.env["NODE_ENV"] = originalNodeEnv;
+    if (originalGatewayToken === undefined) delete process.env["GATEWAY_AUTH_TOKEN"];
+    else process.env["GATEWAY_AUTH_TOKEN"] = originalGatewayToken;
+  });
+
+  it("acknowledges a connect message and creates a session", async () => {
+    const ws = createSocket();
+    const context = createContext({ ws: ws as never });
+
+    await handleMessage(
+      ws as never,
+      {
+        id: "msg-connect",
+        type: "connect",
+        timestamp: Date.now(),
+        payload: {
+          channelType: "webchat",
+          channelId: "device-1",
+          metadata: { userId: "user-1" },
+        },
+      },
+      context,
+    );
+
+    expect(ws.sent[0]?.type).toBe("connect.ack");
+    expect(context.sessionManager.activeSessionCount).toBe(1);
+    expect(context.connectedClients.size).toBe(1);
+  });
+
+  it("returns an auth challenge when production auth is not satisfied", async () => {
+    process.env["NODE_ENV"] = "production";
+    delete process.env["GATEWAY_AUTH_TOKEN"];
+
+    const ws = createSocket();
+    const context = createContext({ ws: ws as never });
+
+    await handleMessage(
+      ws as never,
+      {
+        id: "msg-connect",
+        type: "connect",
+        timestamp: Date.now(),
+        payload: {
+          channelType: "webchat",
+          channelId: "device-2",
+          metadata: {},
+        },
+      },
+      context,
+    );
+
+    expect(ws.sent[0]?.type).toBe("connect.challenge");
+  });
+
+  it("rejects chat messages before connect", async () => {
+    const ws = createSocket();
+    const context = createContext({ ws: ws as never });
+
+    await handleMessage(
+      ws as never,
+      {
+        id: "msg-chat",
+        type: "chat.message",
+        timestamp: Date.now(),
+        sessionId: "missing-session",
+        payload: {
+          role: "user",
+          content: "hello",
+        },
+      },
+      context,
+    );
+
+    expect(ws.sent.at(-1)?.type).toBe("error");
+    expect((ws.sent.at(-1)?.payload as Record<string, unknown>)?.code).toBe("UNAUTHENTICATED");
+  });
+
+  it("routes authenticated chat messages through the orchestrator and streams results", async () => {
+    const ws = createSocket();
+    const context = createContext({ ws: ws as never });
+    const session = context.sessionManager.createSession("agent-1", "webchat", "user-1");
+    context.auth = createAuthContext("device-1", "operator", "token");
+
+    setOrchestratorFactoryForTests(async () => {
+      let streamCallback: ((event: { type: "text" | "tool_use"; text?: string; id?: string; name?: string; input?: unknown }) => void) | null = null;
+      let delegationCallback: ((record: {
+        fromAgentId: string;
+        toAgentId: string;
+        reason: string;
+        task: string;
+        timestamp: number;
+      }) => void) | null = null;
+
+      return {
+        activeAgentCount: 2,
+        async init() {},
+        setStreamCallback(callback) {
+          streamCallback = callback;
+        },
+        setApprovalCallback(_callback) {},
+        setDelegationCallback(callback) {
+          delegationCallback = callback;
+        },
+        async handleMessage() {
+          streamCallback?.({ type: "text", text: "Partial reply" });
+          delegationCallback?.({
+            fromAgentId: "karna-general",
+            toAgentId: "karna-coder",
+            reason: "Needs code help",
+            task: "Review code",
+            timestamp: Date.now(),
+          });
+          return {
+            success: true,
+            response: "Final reply",
+            totalTokens: { inputTokens: 10, outputTokens: 20 },
+            agentId: "karna-coder",
+            delegations: [
+              {
+                fromAgentId: "karna-general",
+                toAgentId: "karna-coder",
+                reason: "Needs code help",
+                task: "Review code",
+                timestamp: Date.now(),
+              },
+            ],
+          };
+        },
+      };
+    });
+
+    await handleMessage(
+      ws as never,
+      {
+        id: "msg-chat",
+        type: "chat.message",
+        timestamp: Date.now(),
+        sessionId: session.id,
+        payload: {
+          role: "user",
+          content: "Please help with code",
+        },
+      },
+      context,
+    );
+
+    const sentTypes = ws.sent.map((message) => message.type);
+    expect(sentTypes).toContain("status");
+    expect(sentTypes).toContain("agent.response.stream");
+    expect(sentTypes).toContain("agent.handoff");
+    expect(sentTypes).toContain("agent.response");
+    expect(sentTypes).toContain("orchestration.status");
+
+    expect(appendToTranscript).toHaveBeenCalledTimes(2);
+    expect(readTranscript).toHaveBeenCalledWith(session.id, 50);
+  });
+});


### PR DESCRIPTION
## Summary
- add a Supabase pgvector memory backend for the agent package
- register gateway memory create/search/get/delete routes with automatic Supabase fallback
- add protocol-level gateway tests for connect/auth/chat routing and new memory route coverage

## Testing
- attempted `npm test -- --run tests/gateway/websocket-protocol.test.ts tests/gateway/memory-routes.test.ts tests/agent/supabase-memory-backend.test.ts` but `vitest` is unavailable because this clone has no local node_modules
- attempted `npm run typecheck` but workspace packages are also missing local dependencies (`tsc` not installed in package node_modules)
- ran `git diff --check`

Closes #6
Refs #2