### PR TITLE
feat(memory): add retention and consolidation maintenance

### DIFF
--- a/agent/src/memory/manager.ts
+++ b/agent/src/memory/manager.ts
@@ -21,6 +21,10 @@ export interface MemoryManagerOptions {
   shortTermTtlMs?: number;
   /** Importance threshold for promoting short-term to long-term. Default: 0.7 */
   promotionThreshold?: number;
+  /** Maximum number of long-term memories to keep per agent. */
+  maxLongTermMemoriesPerAgent?: number;
+  /** Run long-term maintenance on an interval when enabled. */
+  maintenanceIntervalMs?: number;
 }
 
 export interface MemoryContext {
@@ -38,14 +42,27 @@ export class MemoryManager {
   private readonly longTerm: MemoryStore | null;
   private readonly promotionThreshold: number;
   private readonly workingMemoryMaxTokens: number;
+  private readonly maxLongTermMemoriesPerAgent: number | null;
+  private readonly knownAgentIds = new Set<string>();
+  private maintenanceTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor(longTermStore: MemoryStore | null, options?: MemoryManagerOptions) {
     this.longTerm = longTermStore;
     this.promotionThreshold = options?.promotionThreshold ?? 0.7;
     this.workingMemoryMaxTokens = options?.workingMemoryMaxTokens ?? 100_000;
+    this.maxLongTermMemoriesPerAgent = options?.maxLongTermMemoriesPerAgent ?? null;
     this.shortTerm = new ShortTermMemory({
       defaultTtlMs: options?.shortTermTtlMs,
     });
+
+    if (this.longTerm && options?.maintenanceIntervalMs) {
+      this.maintenanceTimer = setInterval(() => {
+        this.runMaintenance().catch((error) => {
+          logger.warn({ error: String(error) }, "Long-term memory maintenance failed");
+        });
+      }, options.maintenanceIntervalMs);
+      this.maintenanceTimer.unref();
+    }
   }
 
   // ─── Working Memory ─────────────────────────────────────────────────────
@@ -119,6 +136,7 @@ export class MemoryManager {
       logger.debug("Long-term memory not available — skipping save");
       return null;
     }
+    this.knownAgentIds.add(input.agentId);
     return this.longTerm.save(input);
   }
 
@@ -174,6 +192,7 @@ export class MemoryManager {
    */
   async promoteToLongTerm(sessionId: string, agentId: string): Promise<number> {
     if (!this.longTerm) return 0;
+    this.knownAgentIds.add(agentId);
 
     const entries = this.shortTerm.getForSession(sessionId);
     const toPromote = entries.filter((e) => e.importance >= this.promotionThreshold);
@@ -206,6 +225,97 @@ export class MemoryManager {
     return promoted;
   }
 
+  /**
+   * Consolidate related long-term memories for an agent into a single summary memory.
+   */
+  async consolidateLongTerm(agentId: string): Promise<number> {
+    if (!this.longTerm) return 0;
+
+    const memories = await this.longTerm.listByAgent(agentId);
+    const groups = new Map<string, MemoryEntry[]>();
+
+    for (const memory of memories) {
+      if (memory.tags.includes("consolidated")) continue;
+      const key = `${memory.sessionId ?? "global"}::${memory.category ?? "general"}`;
+      const group = groups.get(key) ?? [];
+      group.push(memory);
+      groups.set(key, group);
+    }
+
+    let consolidatedGroups = 0;
+    for (const [, group] of groups) {
+      if (group.length < 2) continue;
+
+      const ordered = group.sort((a, b) => a.createdAt - b.createdAt).slice(0, 5);
+      const combinedContent = ordered
+        .map((memory) => memory.summary ?? memory.content)
+        .join("\n- ");
+
+      await this.longTerm.save({
+        agentId,
+        content: `Consolidated memory:\n- ${combinedContent}`,
+        summary: ordered.map((memory) => memory.summary ?? memory.content).join("; ").slice(0, 500),
+        source: "system",
+        priority: "high",
+        category: ordered[0]?.category,
+        sessionId: ordered[0]?.sessionId,
+        tags: Array.from(new Set([...ordered.flatMap((memory) => memory.tags), "consolidated"])),
+      });
+
+      await Promise.all(ordered.map((memory) => this.longTerm!.delete(memory.id)));
+      consolidatedGroups++;
+    }
+
+    if (consolidatedGroups > 0) {
+      logger.info({ agentId, consolidatedGroups }, "Consolidated long-term memories");
+    }
+
+    return consolidatedGroups;
+  }
+
+  /**
+   * Enforce retention rules for long-term memory.
+   */
+  async enforceRetention(agentId: string): Promise<number> {
+    if (!this.longTerm) return 0;
+
+    const memories = await this.longTerm.listByAgent(agentId);
+    const now = Date.now();
+    let deleted = 0;
+
+    for (const memory of memories) {
+      if (memory.expiresAt && memory.expiresAt <= now) {
+        if (await this.longTerm.delete(memory.id)) deleted++;
+      }
+    }
+
+    if (this.maxLongTermMemoriesPerAgent) {
+      const remaining = (await this.longTerm.listByAgent(agentId))
+        .sort((a, b) => b.accessedAt - a.accessedAt);
+      const overflow = remaining.slice(this.maxLongTermMemoriesPerAgent);
+
+      for (const memory of overflow) {
+        if (await this.longTerm.delete(memory.id)) deleted++;
+      }
+    }
+
+    if (deleted > 0) {
+      logger.info({ agentId, deleted }, "Applied long-term memory retention");
+    }
+
+    return deleted;
+  }
+
+  /**
+   * Run consolidation and retention for all known agents.
+   */
+  async runMaintenance(): Promise<void> {
+    for (const agentId of this.knownAgentIds) {
+      await this.consolidateLongTerm(agentId);
+      await this.enforceRetention(agentId);
+    }
+  }
+
   // ─── Cleanup ────────────────────────────────────────────────────────────
 
   /**
@@ -228,5 +338,9 @@ export class MemoryManager {
    */
   stop(): void {
     this.shortTerm.stop();
+    if (this.maintenanceTimer) {
+      clearInterval(this.maintenanceTimer);
+      this.maintenanceTimer = null;
+    }
   }
 }

--- a/agent/src/memory/store.ts
+++ b/agent/src/memory/store.ts
@@ -43,6 +43,7 @@ export interface ScoredMemory extends MemoryEntry {
 export interface MemoryBackend {
   save(input: SaveMemoryInput): Promise<MemoryEntry>;
   search(params: MemorySearchParams): Promise<ScoredMemory[]>;
+  listByAgent(agentId: string): Promise<MemoryEntry[]>;
   getById(id: string): Promise<MemoryEntry | null>;
   delete(id: string): Promise<boolean>;
   updateAccessedAt(id: string): Promise<void>;
@@ -112,6 +113,13 @@ export class MemoryStore {
   }
 
   /**
+   * List all memories for an agent.
+   */
+  async listByAgent(agentId: string): Promise<MemoryEntry[]> {
+    return this.backend.listByAgent(agentId);
+  }
+
+  /**
    * Delete a memory entry.
    */
   async delete(id: string): Promise<boolean> {
@@ -131,6 +139,7 @@ export class MemoryStore {
  */
 export class InMemoryBackend implements MemoryBackend {
   private readonly entries = new Map<string, MemoryEntry>();
+  private readonly agentIds = new Map<string, string>();
   private counter = 0;
 
   async save(input: SaveMemoryInput): Promise<MemoryEntry> {
@@ -159,6 +168,7 @@ export class InMemoryBackend implements MemoryBackend {
     };
 
     this.entries.set(id, entry);
+    this.agentIds.set(id, input.agentId);
     return entry;
   }
 
@@ -201,7 +211,15 @@ export class InMemoryBackend implements MemoryBackend {
     return this.entries.get(id) ?? null;
   }
 
+  async listByAgent(agentId: string): Promise<MemoryEntry[]> {
+    return Array.from(this.entries.entries())
+      .filter(([id]) => this.agentIds.get(id) === agentId)
+      .map(([, entry]) => entry)
+      .sort((a, b) => b.createdAt - a.createdAt);
+  }
+
   async delete(id: string): Promise<boolean> {
+    this.agentIds.delete(id);
     return this.entries.delete(id);
   }
 

--- a/agent/src/memory/supabase-backend.ts
+++ b/agent/src/memory/supabase-backend.ts
@@ -113,6 +113,17 @@ export class SupabaseMemoryBackend implements MemoryBackend {
     return mapRowToEntry(data as Record<string, unknown>);
   }
 
+  async listByAgent(agentId: string): Promise<MemoryEntry[]> {
+    const { data, error } = await this.client
+      .from("memories")
+      .select("*")
+      .eq("agent_id", agentId)
+      .order("created_at", { ascending: false });
+
+    if (error) throw error;
+    return (data ?? []).map((row) => mapRowToEntry(row as Record<string, unknown>));
+  }
+
   async delete(id: string): Promise<boolean> {
     const { error, count } = await this.client
       .from("memories")

--- a/tests/agent/memory-manager.test.ts
+++ b/tests/agent/memory-manager.test.ts
@@ -128,4 +128,63 @@ describe("MemoryManager (3-tier)", () => {
       expect(promoted).toBe(1); // Only the 0.9 importance one
     });
   });
+
+  describe("long-term maintenance", () => {
+    it("enforces max long-term memories per agent", async () => {
+      const retentionStore = new MemoryStore(new InMemoryBackend());
+      const retentionManager = new MemoryManager(retentionStore, {
+        maxLongTermMemoriesPerAgent: 2,
+      });
+
+      await retentionManager.saveLongTerm({
+        agentId: "agent-1",
+        content: "Memory 1",
+        source: "conversation",
+      });
+      await retentionManager.saveLongTerm({
+        agentId: "agent-1",
+        content: "Memory 2",
+        source: "conversation",
+      });
+      await retentionManager.saveLongTerm({
+        agentId: "agent-1",
+        content: "Memory 3",
+        source: "conversation",
+      });
+
+      const deleted = await retentionManager.enforceRetention("agent-1");
+      const remaining = await retentionStore.listByAgent("agent-1");
+
+      expect(deleted).toBe(1);
+      expect(remaining).toHaveLength(2);
+      retentionManager.stop();
+    });
+
+    it("consolidates related long-term memories into a summary memory", async () => {
+      await manager.saveLongTerm({
+        agentId: "agent-1",
+        content: "User prefers concise answers",
+        source: "conversation",
+        sessionId: "session-1",
+        category: "preference",
+        tags: ["preference"],
+      });
+      await manager.saveLongTerm({
+        agentId: "agent-1",
+        content: "User likes bullet lists",
+        source: "conversation",
+        sessionId: "session-1",
+        category: "preference",
+        tags: ["formatting"],
+      });
+
+      const consolidated = await manager.consolidateLongTerm("agent-1");
+      const remaining = await longTermStore.listByAgent("agent-1");
+
+      expect(consolidated).toBe(1);
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0]?.tags).toContain("consolidated");
+      expect(remaining[0]?.content).toContain("Consolidated memory");
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- extend the long-term memory store with agent-scoped listing so maintenance can operate on persisted memories
- add MemoryManager maintenance helpers for consolidation, retention, and optional scheduled upkeep
- cover retention and consolidation behavior in memory manager tests

## Testing
- attempted `npm test -- --run tests/agent/memory-manager.test.ts` but `vitest` is unavailable because this clone has no local node_modules
- attempted `npm run typecheck` earlier in this clone but workspace packages are missing local dependencies (`tsc` not installed in package node_modules)
- ran `git diff --check`

Closes #2