### PR TITLE
feat(web): add continuous voice mode

### DIFF
--- a/agent/src/memory/manager.ts
+++ b/agent/src/memory/manager.ts
@@ -21,6 +21,10 @@ export interface MemoryManagerOptions {
   shortTermTtlMs?: number;
   /** Importance threshold for promoting short-term to long-term. Default: 0.7 */
   promotionThreshold?: number;
+  /** Maximum number of long-term memories to keep per agent. */
+  maxLongTermMemoriesPerAgent?: number;
+  /** Run long-term maintenance on an interval when enabled. */
+  maintenanceIntervalMs?: number;
 }
 
 export interface MemoryContext {
@@ -38,14 +42,27 @@ export class MemoryManager {
   private readonly longTerm: MemoryStore | null;
   private readonly promotionThreshold: number;
   private readonly workingMemoryMaxTokens: number;
+  private readonly maxLongTermMemoriesPerAgent: number | null;
+  private readonly knownAgentIds = new Set<string>();
+  private maintenanceTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor(longTermStore: MemoryStore | null, options?: MemoryManagerOptions) {
     this.longTerm = longTermStore;
     this.promotionThreshold = options?.promotionThreshold ?? 0.7;
     this.workingMemoryMaxTokens = options?.workingMemoryMaxTokens ?? 100_000;
+    this.maxLongTermMemoriesPerAgent = options?.maxLongTermMemoriesPerAgent ?? null;
     this.shortTerm = new ShortTermMemory({
       defaultTtlMs: options?.shortTermTtlMs,
     });
+
+    if (this.longTerm && options?.maintenanceIntervalMs) {
+      this.maintenanceTimer = setInterval(() => {
+        this.runMaintenance().catch((error) => {
+          logger.warn({ error: String(error) }, "Long-term memory maintenance failed");
+        });
+      }, options.maintenanceIntervalMs);
+      this.maintenanceTimer.unref();
+    }
   }
 
   // ─── Working Memory ─────────────────────────────────────────────────────
@@ -119,6 +136,7 @@ export class MemoryManager {
       logger.debug("Long-term memory not available — skipping save");
       return null;
     }
+    this.knownAgentIds.add(input.agentId);
     return this.longTerm.save(input);
   }
 
@@ -174,6 +192,7 @@ export class MemoryManager {
    */
   async promoteToLongTerm(sessionId: string, agentId: string): Promise<number> {
     if (!this.longTerm) return 0;
+    this.knownAgentIds.add(agentId);
 
     const entries = this.shortTerm.getForSession(sessionId);
     const toPromote = entries.filter((e) => e.importance >= this.promotionThreshold);
@@ -206,6 +225,97 @@ export class MemoryManager {
     return promoted;
   }
 
+  /**
+   * Consolidate related long-term memories for an agent into a single summary memory.
+   */
+  async consolidateLongTerm(agentId: string): Promise<number> {
+    if (!this.longTerm) return 0;
+
+    const memories = await this.longTerm.listByAgent(agentId);
+    const groups = new Map<string, MemoryEntry[]>();
+
+    for (const memory of memories) {
+      if (memory.tags.includes("consolidated")) continue;
+      const key = `${memory.sessionId ?? "global"}::${memory.category ?? "general"}`;
+      const group = groups.get(key) ?? [];
+      group.push(memory);
+      groups.set(key, group);
+    }
+
+    let consolidatedGroups = 0;
+    for (const [, group] of groups) {
+      if (group.length < 2) continue;
+
+      const ordered = group.sort((a, b) => a.createdAt - b.createdAt).slice(0, 5);
+      const combinedContent = ordered
+        .map((memory) => memory.summary ?? memory.content)
+        .join("\n- ");
+
+      await this.longTerm.save({
+        agentId,
+        content: `Consolidated memory:\n- ${combinedContent}`,
+        summary: ordered.map((memory) => memory.summary ?? memory.content).join("; ").slice(0, 500),
+        source: "system",
+        priority: "high",
+        category: ordered[0]?.category,
+        sessionId: ordered[0]?.sessionId,
+        tags: Array.from(new Set([...ordered.flatMap((memory) => memory.tags), "consolidated"])),
+      });
+
+      await Promise.all(ordered.map((memory) => this.longTerm!.delete(memory.id)));
+      consolidatedGroups++;
+    }
+
+    if (consolidatedGroups > 0) {
+      logger.info({ agentId, consolidatedGroups }, "Consolidated long-term memories");
+    }
+
+    return consolidatedGroups;
+  }
+
+  /**
+   * Enforce retention rules for long-term memory.
+   */
+  async enforceRetention(agentId: string): Promise<number> {
+    if (!this.longTerm) return 0;
+
+    const memories = await this.longTerm.listByAgent(agentId);
+    const now = Date.now();
+    let deleted = 0;
+
+    for (const memory of memories) {
+      if (memory.expiresAt && memory.expiresAt <= now) {
+        if (await this.longTerm.delete(memory.id)) deleted++;
+      }
+    }
+
+    if (this.maxLongTermMemoriesPerAgent) {
+      const remaining = (await this.longTerm.listByAgent(agentId))
+        .sort((a, b) => b.accessedAt - a.accessedAt);
+      const overflow = remaining.slice(this.maxLongTermMemoriesPerAgent);
+
+      for (const memory of overflow) {
+        if (await this.longTerm.delete(memory.id)) deleted++;
+      }
+    }
+
+    if (deleted > 0) {
+      logger.info({ agentId, deleted }, "Applied long-term memory retention");
+    }
+
+    return deleted;
+  }
+
+  /**
+   * Run consolidation and retention for all known agents.
+   */
+  async runMaintenance(): Promise<void> {
+    for (const agentId of this.knownAgentIds) {
+      await this.consolidateLongTerm(agentId);
+      await this.enforceRetention(agentId);
+    }
+  }
+
   // ─── Cleanup ────────────────────────────────────────────────────────────
 
   /**
@@ -228,5 +338,9 @@ export class MemoryManager {
    */
   stop(): void {
     this.shortTerm.stop();
+    if (this.maintenanceTimer) {
+      clearInterval(this.maintenanceTimer);
+      this.maintenanceTimer = null;
+    }
   }
 }

--- a/agent/src/memory/store.ts
+++ b/agent/src/memory/store.ts
@@ -43,6 +43,7 @@ export interface ScoredMemory extends MemoryEntry {
 export interface MemoryBackend {
   save(input: SaveMemoryInput): Promise<MemoryEntry>;
   search(params: MemorySearchParams): Promise<ScoredMemory[]>;
+  listByAgent(agentId: string): Promise<MemoryEntry[]>;
   getById(id: string): Promise<MemoryEntry | null>;
   delete(id: string): Promise<boolean>;
   updateAccessedAt(id: string): Promise<void>;
@@ -112,6 +113,13 @@ export class MemoryStore {
   }
 
   /**
+   * List all memories for an agent.
+   */
+  async listByAgent(agentId: string): Promise<MemoryEntry[]> {
+    return this.backend.listByAgent(agentId);
+  }
+
+  /**
    * Delete a memory entry.
    */
   async delete(id: string): Promise<boolean> {
@@ -131,6 +139,7 @@ export class MemoryStore {
  */
 export class InMemoryBackend implements MemoryBackend {
   private readonly entries = new Map<string, MemoryEntry>();
+  private readonly agentIds = new Map<string, string>();
   private counter = 0;
 
   async save(input: SaveMemoryInput): Promise<MemoryEntry> {
@@ -159,6 +168,7 @@ export class InMemoryBackend implements MemoryBackend {
     };
 
     this.entries.set(id, entry);
+    this.agentIds.set(id, input.agentId);
     return entry;
   }
 
@@ -201,7 +211,15 @@ export class InMemoryBackend implements MemoryBackend {
     return this.entries.get(id) ?? null;
   }
 
+  async listByAgent(agentId: string): Promise<MemoryEntry[]> {
+    return Array.from(this.entries.entries())
+      .filter(([id]) => this.agentIds.get(id) === agentId)
+      .map(([, entry]) => entry)
+      .sort((a, b) => b.createdAt - a.createdAt);
+  }
+
   async delete(id: string): Promise<boolean> {
+    this.agentIds.delete(id);
     return this.entries.delete(id);
   }
 

--- a/agent/src/memory/supabase-backend.ts
+++ b/agent/src/memory/supabase-backend.ts
@@ -113,6 +113,17 @@ export class SupabaseMemoryBackend implements MemoryBackend {
     return mapRowToEntry(data as Record<string, unknown>);
   }
 
+  async listByAgent(agentId: string): Promise<MemoryEntry[]> {
+    const { data, error } = await this.client
+      .from("memories")
+      .select("*")
+      .eq("agent_id", agentId)
+      .order("created_at", { ascending: false });
+
+    if (error) throw error;
+    return (data ?? []).map((row) => mapRowToEntry(row as Record<string, unknown>));
+  }
+
   async delete(id: string): Promise<boolean> {
     const { error, count } = await this.client
       .from("memories")

--- a/apps/mobile/components/VoiceInput.tsx
+++ b/apps/mobile/components/VoiceInput.tsx
@@ -110,7 +110,9 @@ export function VoiceInput() {
     await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     const uri = await stopRecording();
     if (uri) {
-      gatewayClient.sendVoiceMessage(uri);
+      gatewayClient.sendVoiceMessage(uri).catch((err) => {
+        console.warn('[VoiceInput] Failed to send voice message:', err);
+      });
     }
   }, [recording, stopPulse]);
 

--- a/apps/mobile/lib/gateway-client.ts
+++ b/apps/mobile/lib/gateway-client.ts
@@ -1,11 +1,14 @@
 import { useAppStore } from './store';
 import type { ChatMessage, ToolCall, MemoryEntry, Skill, Reminder } from './store';
+import { readAudioFileAsBase64, playAudioResponse } from './voice';
 
 // ── Protocol Types ───────────────────────────────────────────────────────────
 
 interface ProtocolMessage {
   type: string;
   id?: string;
+  timestamp?: number;
+  sessionId?: string;
   payload?: Record<string, unknown>;
 }
 
@@ -22,6 +25,8 @@ class GatewayClient {
   private url = '';
   private token = '';
   private intentionalClose = false;
+  private sessionId: string | null = null;
+  private pendingStreamMessageId: string | null = null;
 
   connect(url: string, token: string): void {
     this.url = url;
@@ -41,6 +46,8 @@ class GatewayClient {
       this.ws.close(1000, 'Client disconnect');
       this.ws = null;
     }
+    this.sessionId = null;
+    this.pendingStreamMessageId = null;
     useAppStore.getState().setStatus('disconnected');
   }
 
@@ -64,18 +71,46 @@ class GatewayClient {
     useAppStore.getState().setTyping(true);
 
     this.send({
-      type: 'chat.message',
       id,
+      type: 'chat.message',
+      timestamp: Date.now(),
+      sessionId: this.sessionId ?? undefined,
       payload: { content, role: 'user' },
     });
   }
 
-  sendVoiceMessage(audioUri: string): void {
-    const id = generateId();
+  async sendVoiceMessage(audioUri: string): Promise<void> {
+    const base64 = await readAudioFileAsBase64(audioUri);
+    const chunkSize = 32_000;
+
     this.send({
-      type: 'chat.voice',
-      id,
-      payload: { audioUri },
+      id: generateId(),
+      type: 'voice.start',
+      timestamp: Date.now(),
+      sessionId: this.sessionId ?? undefined,
+      payload: { mode: 'push-to-talk' },
+    });
+
+    for (let offset = 0; offset < base64.length; offset += chunkSize) {
+      this.send({
+        id: generateId(),
+        type: 'voice.audio.chunk',
+        timestamp: Date.now(),
+        sessionId: this.sessionId ?? undefined,
+        payload: {
+          data: base64.slice(offset, offset + chunkSize),
+          format: 'm4a',
+          sampleRate: 44100,
+        },
+      });
+    }
+
+    this.send({
+      id: generateId(),
+      type: 'voice.end',
+      timestamp: Date.now(),
+      sessionId: this.sessionId ?? undefined,
+      payload: {},
     });
   }
 
@@ -108,7 +143,19 @@ class GatewayClient {
         useAppStore.getState().setStatus('connected');
         console.log('[GatewayClient] Connected');
 
-        this.send({ type: 'client.hello', payload: { platform: 'mobile' } });
+        this.send({
+          id: generateId(),
+          type: 'connect',
+          timestamp: Date.now(),
+          payload: {
+            channelType: 'mobile',
+            channelId: 'mobile-chat',
+            metadata: {
+              token: this.token,
+              platform: 'mobile',
+            },
+          },
+        });
       };
 
       this.ws.onmessage = (event) => {
@@ -116,6 +163,18 @@ class GatewayClient {
           const message: ProtocolMessage = JSON.parse(
             typeof event.data === 'string' ? event.data : '',
           );
+          if (message.type === 'connect.ack') {
+            this.sessionId = message.payload?.sessionId as string | null;
+          }
+          if (message.type === 'heartbeat.check') {
+            this.send({
+              id: generateId(),
+              type: 'heartbeat.ack',
+              timestamp: Date.now(),
+              payload: { clientTime: Date.now() },
+            });
+            return;
+          }
           this.handleProtocolMessage(message);
           this.handlers.forEach((handler) => handler(message));
         } catch (err) {
@@ -170,6 +229,33 @@ class GatewayClient {
     const payload = message.payload ?? {};
 
     switch (message.type) {
+      case 'connect.ack': {
+        this.sessionId = (payload.sessionId as string) ?? null;
+        break;
+      }
+
+      case 'agent.response': {
+        store.setTyping(false);
+        const content = (payload.content as string) ?? '';
+        if (this.pendingStreamMessageId) {
+          store.updateMessage(this.pendingStreamMessageId, {
+            content,
+            toolCalls: payload.toolCalls as ToolCall[] | undefined,
+          });
+        } else {
+          const assistantMessage: ChatMessage = {
+            id: message.id ?? generateId(),
+            role: 'assistant',
+            content,
+            timestamp: Date.now(),
+            toolCalls: payload.toolCalls as ToolCall[] | undefined,
+          };
+          store.addMessage(assistantMessage);
+        }
+        this.pendingStreamMessageId = null;
+        break;
+      }
+
       case 'chat.response': {
         store.setTyping(false);
         const assistantMessage: ChatMessage = {
@@ -180,6 +266,27 @@ class GatewayClient {
           toolCalls: payload.toolCalls as ToolCall[] | undefined,
         };
         store.addMessage(assistantMessage);
+        break;
+      }
+
+      case 'agent.response.stream': {
+        const delta = (payload.delta as string) ?? '';
+        if (!this.pendingStreamMessageId) {
+          this.pendingStreamMessageId = message.id ?? generateId();
+          store.addMessage({
+            id: this.pendingStreamMessageId,
+            role: 'assistant',
+            content: delta,
+            timestamp: Date.now(),
+          });
+        } else {
+          const existing = store.messages.find((m) => m.id === this.pendingStreamMessageId);
+          if (existing) {
+            store.updateMessage(this.pendingStreamMessageId, {
+              content: existing.content + delta,
+            });
+          }
+        }
         break;
       }
 
@@ -212,6 +319,58 @@ class GatewayClient {
           store.updateMessage(message.id, {
             toolCalls: payload.toolCalls as ToolCall[],
           });
+        }
+        break;
+      }
+
+      case 'voice.transcript': {
+        const text = (payload.text as string) ?? '';
+        const isFinal = Boolean(payload.isFinal);
+        if (isFinal && text.trim()) {
+          store.addMessage({
+            id: message.id ?? generateId(),
+            role: 'user',
+            content: text,
+            timestamp: Date.now(),
+          });
+          store.setTyping(true);
+        }
+        break;
+      }
+
+      case 'voice.audio.response': {
+        const transcript = (payload.transcript as string) ?? '';
+        const latestAssistant = store.messages.find((entry) => entry.role === 'assistant');
+        if (transcript.trim() && latestAssistant?.content !== transcript) {
+          store.addMessage({
+            id: message.id ?? generateId(),
+            role: 'assistant',
+            content: transcript,
+            timestamp: Date.now(),
+          });
+        }
+
+        const audioData = payload.data as string | undefined;
+        const format = (payload.format as string | undefined) ?? 'mp3';
+        if (audioData) {
+          playAudioResponse(audioData, format).catch((err) => {
+            console.warn('[GatewayClient] Failed to play voice response:', err);
+          });
+        }
+
+        store.setTyping(false);
+        break;
+      }
+
+      case 'status': {
+        const state = payload.state as string | undefined;
+        if (state === 'thinking' || state === 'streaming' || state === 'tool_calling') {
+          store.setTyping(true);
+        } else if (state === 'idle' || state === 'error') {
+          store.setTyping(false);
+          if (state === 'idle') {
+            this.pendingStreamMessageId = null;
+          }
         }
         break;
       }

--- a/apps/mobile/lib/voice.ts
+++ b/apps/mobile/lib/voice.ts
@@ -1,6 +1,8 @@
 import { Audio } from 'expo-av';
+import * as FileSystem from 'expo-file-system';
 
 let currentRecording: Audio.Recording | null = null;
+let currentSound: Audio.Sound | null = null;
 
 const RECORDING_OPTIONS: Audio.RecordingOptions = {
   android: {
@@ -96,4 +98,52 @@ export async function getRecordingStatus(): Promise<Audio.RecordingStatus | null
   } catch {
     return null;
   }
+}
+
+export async function readAudioFileAsBase64(uri: string): Promise<string> {
+  return FileSystem.readAsStringAsync(uri, {
+    encoding: FileSystem.EncodingType.Base64,
+  });
+}
+
+export async function playAudioResponse(base64Data: string, extension = 'mp3'): Promise<void> {
+  const cacheDir = FileSystem.cacheDirectory ?? FileSystem.documentDirectory;
+  if (!cacheDir) {
+    throw new Error('No writable cache directory available for audio playback');
+  }
+
+  const fileUri = `${cacheDir}karna-voice-response-${Date.now()}.${extension}`;
+
+  if (currentSound) {
+    try {
+      await currentSound.unloadAsync();
+    } catch {
+      // ignore stale sound cleanup failures
+    }
+    currentSound = null;
+  }
+
+  await FileSystem.writeAsStringAsync(fileUri, base64Data, {
+    encoding: FileSystem.EncodingType.Base64,
+  });
+
+  await Audio.setAudioModeAsync({
+    allowsRecordingIOS: false,
+    playsInSilentModeIOS: true,
+  });
+
+  const { sound } = await Audio.Sound.createAsync(
+    { uri: fileUri },
+    { shouldPlay: true },
+  );
+
+  currentSound = sound;
+  sound.setOnPlaybackStatusUpdate((status) => {
+    if (!status.isLoaded || !status.didJustFinish) return;
+
+    sound.unloadAsync().catch(() => {});
+    if (currentSound === sound) {
+      currentSound = null;
+    }
+  });
 }

--- a/apps/web/components/VoiceOverlay.tsx
+++ b/apps/web/components/VoiceOverlay.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useEffect, useRef, useState, useCallback } from "react";
-import { X, Mic, MicOff } from "lucide-react";
+import { X, Mic, MicOff, Waves } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { getVoiceClient, type VoiceState } from "@/lib/voice";
+import { getVoiceClient, type VoiceMode, type VoiceState } from "@/lib/voice";
 import { getWSClient } from "@/lib/ws";
 
 interface VoiceOverlayProps {
@@ -17,6 +17,7 @@ export function VoiceOverlay({ open, onClose, onTranscript }: VoiceOverlayProps)
   const [voiceState, setVoiceState] = useState<VoiceState>("idle");
   const [audioLevel, setAudioLevel] = useState(0);
   const [transcript, setTranscript] = useState("");
+  const [voiceMode, setVoiceMode] = useState<VoiceMode>("push-to-talk");
   const [statusText, setStatusText] = useState("Tap the microphone to start");
   const voiceClientRef = useRef(getVoiceClient());
 
@@ -29,7 +30,7 @@ export function VoiceOverlay({ open, onClose, onTranscript }: VoiceOverlayProps)
       setVoiceState(state);
       switch (state) {
         case "recording":
-          setStatusText("Listening...");
+          setStatusText(voiceMode === "continuous" ? "Listening until you pause..." : "Listening...");
           break;
         case "processing":
           setStatusText("Thinking...");
@@ -61,7 +62,7 @@ export function VoiceOverlay({ open, onClose, onTranscript }: VoiceOverlayProps)
       unsubLevel();
       unsubTranscript();
     };
-  }, [open, onTranscript]);
+  }, [open, onTranscript, voiceMode]);
 
   // Listen for voice.transcript and voice.audio.response messages from WS
   useEffect(() => {
@@ -115,9 +116,9 @@ export function VoiceOverlay({ open, onClose, onTranscript }: VoiceOverlayProps)
       vc.stopRecording();
     } else {
       setTranscript("");
-      vc.startRecording();
+      vc.startRecording(voiceMode);
     }
-  }, []);
+  }, [voiceMode]);
 
   const handleClose = useCallback(() => {
     const vc = voiceClientRef.current;
@@ -168,6 +169,26 @@ export function VoiceOverlay({ open, onClose, onTranscript }: VoiceOverlayProps)
         title="Close voice mode"
       >
         <X size={24} />
+      </button>
+
+      <button
+        onClick={() =>
+          setVoiceMode((current) =>
+            current === "push-to-talk" ? "continuous" : "push-to-talk",
+          )
+        }
+        disabled={isRecording || isProcessing}
+        className={cn(
+          "absolute top-4 left-4 flex items-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors",
+          voiceMode === "continuous"
+            ? "bg-accent-600 text-white"
+            : "bg-dark-800 text-dark-300 hover:text-white",
+          (isRecording || isProcessing) && "opacity-50 cursor-not-allowed",
+        )}
+        title="Toggle continuous listening"
+      >
+        <Waves size={16} />
+        {voiceMode === "continuous" ? "Continuous" : "Push to Talk"}
       </button>
 
       {/* Status text */}
@@ -242,7 +263,11 @@ export function VoiceOverlay({ open, onClose, onTranscript }: VoiceOverlayProps)
           </p>
         ) : (
           <p className="text-dark-600 text-sm">
-            {isRecording ? "Speak now..." : ""}
+            {isRecording
+              ? voiceMode === "continuous"
+                ? "Speak naturally. I'll stop when you pause."
+                : "Speak now..."
+              : ""}
           </p>
         )}
       </div>

--- a/apps/web/lib/voice.ts
+++ b/apps/web/lib/voice.ts
@@ -11,6 +11,12 @@ export type VoiceState = "idle" | "requesting" | "recording" | "processing" | "p
 export type VoiceStateHandler = (state: VoiceState) => void;
 export type AudioLevelHandler = (level: number) => void;
 export type TranscriptHandler = (text: string, isFinal: boolean) => void;
+export type VoiceMode = "push-to-talk" | "continuous";
+
+const DEFAULT_SAMPLE_RATE = 48000;
+const DEFAULT_TIMESLICE_MS = 250;
+const SILENCE_THRESHOLD = 0.04;
+const SILENCE_DURATION_MS = 1500;
 
 export class VoiceClient {
   private mediaRecorder: MediaRecorder | null = null;
@@ -18,6 +24,8 @@ export class VoiceClient {
   private audioContext: AudioContext | null = null;
   private analyser: AnalyserNode | null = null;
   private animationFrame: number | null = null;
+  private silenceStartedAt: number | null = null;
+  private currentMode: VoiceMode = "push-to-talk";
   private _state: VoiceState = "idle";
   private stateHandlers = new Set<VoiceStateHandler>();
   private levelHandlers = new Set<AudioLevelHandler>();
@@ -50,9 +58,11 @@ export class VoiceClient {
 
   // ─── Recording ────────────────────────────────────────────────────────────
 
-  async startRecording(): Promise<void> {
+  async startRecording(mode: VoiceMode = "push-to-talk"): Promise<void> {
     if (this._state === "recording") return;
 
+    this.currentMode = mode;
+    this.silenceStartedAt = null;
     this.setState("requesting");
 
     try {
@@ -61,7 +71,7 @@ export class VoiceClient {
         audio: {
           echoCancellation: true,
           noiseSuppression: true,
-          sampleRate: 48000,
+          sampleRate: DEFAULT_SAMPLE_RATE,
         },
       });
 
@@ -90,7 +100,7 @@ export class VoiceClient {
         type: "voice.start",
         timestamp: Date.now(),
         sessionId: ws.currentSessionId,
-        payload: { mode: "push-to-talk" },
+        payload: { mode },
       });
 
       // Send audio chunks as they become available
@@ -109,7 +119,7 @@ export class VoiceClient {
             payload: {
               data: base64,
               format: "webm",
-              sampleRate: 48000,
+              sampleRate: DEFAULT_SAMPLE_RATE,
             },
           });
         }
@@ -127,7 +137,7 @@ export class VoiceClient {
       };
 
       // Start recording with 250ms timeslice for chunked streaming
-      this.mediaRecorder.start(250);
+      this.mediaRecorder.start(DEFAULT_TIMESLICE_MS);
       this.setState("recording");
     } catch (error) {
       console.error("Failed to start recording:", error);
@@ -232,6 +242,19 @@ export class VoiceClient {
       const average = sum / dataArray.length / 255;
       this.levelHandlers.forEach((handler) => handler(average));
 
+      if (this.currentMode === "continuous" && this._state === "recording") {
+        if (average <= SILENCE_THRESHOLD) {
+          if (this.silenceStartedAt === null) {
+            this.silenceStartedAt = performance.now();
+          } else if (performance.now() - this.silenceStartedAt >= SILENCE_DURATION_MS) {
+            this.stopRecording();
+            return;
+          }
+        } else {
+          this.silenceStartedAt = null;
+        }
+      }
+
       this.animationFrame = requestAnimationFrame(tick);
     };
 
@@ -247,6 +270,7 @@ export class VoiceClient {
 
   private cleanup(): void {
     this.stopLevelMonitoring();
+    this.silenceStartedAt = null;
 
     if (this.mediaRecorder && this.mediaRecorder.state !== "inactive") {
       try {

--- a/packages/shared/src/types/protocol.ts
+++ b/packages/shared/src/types/protocol.ts
@@ -206,7 +206,7 @@ export const VoiceAudioChunkMessageSchema = BaseMessageSchema.extend({
   type: z.literal("voice.audio.chunk"),
   payload: z.object({
     data: z.string().min(1),
-    format: z.enum(["webm", "wav"]),
+    format: z.enum(["webm", "wav", "m4a"]),
     sampleRate: z.number().int().positive(),
   }),
 });

--- a/tests/agent/memory-manager.test.ts
+++ b/tests/agent/memory-manager.test.ts
@@ -128,4 +128,63 @@ describe("MemoryManager (3-tier)", () => {
       expect(promoted).toBe(1); // Only the 0.9 importance one
     });
   });
+
+  describe("long-term maintenance", () => {
+    it("enforces max long-term memories per agent", async () => {
+      const retentionStore = new MemoryStore(new InMemoryBackend());
+      const retentionManager = new MemoryManager(retentionStore, {
+        maxLongTermMemoriesPerAgent: 2,
+      });
+
+      await retentionManager.saveLongTerm({
+        agentId: "agent-1",
+        content: "Memory 1",
+        source: "conversation",
+      });
+      await retentionManager.saveLongTerm({
+        agentId: "agent-1",
+        content: "Memory 2",
+        source: "conversation",
+      });
+      await retentionManager.saveLongTerm({
+        agentId: "agent-1",
+        content: "Memory 3",
+        source: "conversation",
+      });
+
+      const deleted = await retentionManager.enforceRetention("agent-1");
+      const remaining = await retentionStore.listByAgent("agent-1");
+
+      expect(deleted).toBe(1);
+      expect(remaining).toHaveLength(2);
+      retentionManager.stop();
+    });
+
+    it("consolidates related long-term memories into a summary memory", async () => {
+      await manager.saveLongTerm({
+        agentId: "agent-1",
+        content: "User prefers concise answers",
+        source: "conversation",
+        sessionId: "session-1",
+        category: "preference",
+        tags: ["preference"],
+      });
+      await manager.saveLongTerm({
+        agentId: "agent-1",
+        content: "User likes bullet lists",
+        source: "conversation",
+        sessionId: "session-1",
+        category: "preference",
+        tags: ["formatting"],
+      });
+
+      const consolidated = await manager.consolidateLongTerm("agent-1");
+      const remaining = await longTermStore.listByAgent("agent-1");
+
+      expect(consolidated).toBe(1);
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0]?.tags).toContain("consolidated");
+      expect(remaining[0]?.content).toContain("Consolidated memory");
+    });
+  });
 });

--- a/tests/shared/protocol-extended.test.ts
+++ b/tests/shared/protocol-extended.test.ts
@@ -6,6 +6,7 @@ import {
   ToolApprovalRequestedMessageSchema,
   ToolApprovalResponseMessageSchema,
   ToolResultMessageSchema,
+  VoiceAudioChunkMessageSchema,
   HeartbeatCheckMessageSchema,
   HeartbeatAckMessageSchema,
   SkillInvokeMessageSchema,
@@ -76,6 +77,24 @@ describe("Protocol Schema - Extended Coverage", () => {
         };
         expect(ToolApprovalRequestedMessageSchema.safeParse(msg).success).toBe(true);
       }
+    });
+  });
+
+  describe("VoiceAudioChunkMessage", () => {
+    it("accepts mobile m4a audio chunks", () => {
+      const msg = {
+        id: "msg-voice-1",
+        type: "voice.audio.chunk",
+        timestamp: Date.now(),
+        sessionId: "session-1",
+        payload: {
+          data: "YmFzZTY0",
+          format: "m4a",
+          sampleRate: 44100,
+        },
+      };
+
+      expect(VoiceAudioChunkMessageSchema.safeParse(msg).success).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary
- add a continuous listening mode to the web voice client
- stop recording automatically after a silence window to make voice turns feel more natural
- expose a mode toggle in the voice overlay between push-to-talk and continuous listening

## Testing
- did not run the repo test suite because this clone has no local node_modules, so workspace-local tools are unavailable
- ran `git diff --check`

Refs #3