### PR TITLE
feat(gateway): add WebRTC signaling relay

### DIFF
--- a/apps/mobile/lib/gateway-client.ts
+++ b/apps/mobile/lib/gateway-client.ts
@@ -27,6 +27,7 @@ class GatewayClient {
   private intentionalClose = false;
   private sessionId: string | null = null;
   private pendingStreamMessageId: string | null = null;
+  private channelId = `mobile-${generateId()}`;
 
   connect(url: string, token: string): void {
     this.url = url;
@@ -149,7 +150,7 @@ class GatewayClient {
           timestamp: Date.now(),
           payload: {
             channelType: 'mobile',
-            channelId: 'mobile-chat',
+            channelId: this.channelId,
             metadata: {
               token: this.token,
               platform: 'mobile',
@@ -165,6 +166,7 @@ class GatewayClient {
           );
           if (message.type === 'connect.ack') {
             this.sessionId = message.payload?.sessionId as string | null;
+            this.channelId = (message.payload?.channelId as string | undefined) ?? this.channelId;
           }
           if (message.type === 'heartbeat.check') {
             this.send({
@@ -231,6 +233,7 @@ class GatewayClient {
     switch (message.type) {
       case 'connect.ack': {
         this.sessionId = (payload.sessionId as string) ?? null;
+        this.channelId = (payload.channelId as string | undefined) ?? this.channelId;
         break;
       }
 

--- a/apps/web/lib/ws.ts
+++ b/apps/web/lib/ws.ts
@@ -10,6 +10,7 @@ interface WSClientOptions {
   reconnectInterval?: number;
   maxReconnectAttempts?: number;
   heartbeatInterval?: number;
+  channelId?: string;
 }
 
 export class WSClient {
@@ -26,12 +27,14 @@ export class WSClient {
   private _state: WSState = "disconnected";
   private sessionId: string | null = null;
   private token: string | null = null;
+  private channelId: string;
 
   constructor(options: WSClientOptions = {}) {
     this.url = options.url ?? process.env.NEXT_PUBLIC_WS_URL ?? "ws://localhost:4000/ws";
     this.reconnectInterval = options.reconnectInterval ?? 3000;
     this.maxReconnectAttempts = options.maxReconnectAttempts ?? 10;
     this.heartbeatInterval = options.heartbeatInterval ?? 30000;
+    this.channelId = options.channelId ?? `web-${crypto.randomUUID()}`;
   }
 
   get state(): WSState {
@@ -42,8 +45,13 @@ export class WSClient {
     return this.sessionId;
   }
 
-  connect(channelId = "web-chat"): void {
+  get currentChannelId(): string {
+    return this.channelId;
+  }
+
+  connect(channelId?: string): void {
     if (this.ws?.readyState === WebSocket.OPEN) return;
+    if (channelId) this.channelId = channelId;
 
     this.setState("connecting");
     this.ws = new WebSocket(this.url);
@@ -57,7 +65,7 @@ export class WSClient {
         timestamp: Date.now(),
         payload: {
           channelType: "web",
-          channelId,
+          channelId: this.channelId,
         },
       });
       this.startHeartbeat();
@@ -69,6 +77,9 @@ export class WSClient {
         // Handle connect.ack to store session info
         if (data.type === "connect.ack") {
           this.sessionId = data.payload.sessionId;
+          if (typeof data.payload.channelId === "string") {
+            this.channelId = data.payload.channelId;
+          }
           this.token = data.payload.token;
         }
         // Handle heartbeat checks

--- a/gateway/src/protocol/handler.ts
+++ b/gateway/src/protocol/handler.ts
@@ -9,6 +9,10 @@ import type {
   VoiceStartMessage,
   VoiceAudioChunkMessage,
   VoiceEndMessage,
+  RTCOfferMessage,
+  RTCAnswerMessage,
+  RTCIceCandidateMessage,
+  RTCHangupMessage,
 } from "./schema.js";
 import type { AuthContext } from "./auth.js";
 import { validateToken, generateChallenge, verifyChallenge, createAuthContext } from "./auth.js";
@@ -219,6 +223,17 @@ export async function handleMessage(
         await handleVoiceEnd(ws, (message as VoiceEndMessage).payload, context);
         break;
 
+      case "rtc.offer":
+      case "rtc.answer":
+      case "rtc.ice-candidate":
+      case "rtc.hangup":
+        await handleRTCSignal(
+          ws,
+          message as RTCOfferMessage | RTCAnswerMessage | RTCIceCandidateMessage | RTCHangupMessage,
+          context,
+        );
+        break;
+
       default:
         logger.warn({ type: message.type }, "Unhandled message type");
         sendError(ws, "UNHANDLED_TYPE", `No handler for message type: ${message.type}`);
@@ -295,6 +310,7 @@ async function handleConnect(
     timestamp: Date.now(),
     payload: {
       sessionId: session.id,
+      channelId,
       token: nanoid(32),
       expiresAt: Date.now() + 3_600_000, // 1 hour
     },
@@ -659,7 +675,51 @@ async function handleSkillInvoke(
   });
 }
 
+async function handleRTCSignal(
+  ws: WebSocket,
+  message: RTCOfferMessage | RTCAnswerMessage | RTCIceCandidateMessage | RTCHangupMessage,
+  context: ConnectionContext,
+): Promise<void> {
+  if (!context.auth) {
+    sendError(ws, "UNAUTHENTICATED", "Must send a 'connect' message before RTC signaling");
+    return;
+  }
+
+  const sourceChannelId = resolveClientIdBySocket(context.connectedClients, ws) ?? context.auth.channelId;
+  const targetChannelId = message.payload.targetChannelId;
+  const targetClient = context.connectedClients.get(targetChannelId);
+
+  if (!targetClient || targetClient.ws.readyState !== targetClient.ws.OPEN) {
+    sendError(ws, "RTC_PEER_NOT_FOUND", `Target peer ${targetChannelId} is not connected`);
+    return;
+  }
+
+  sendMessage(targetClient.ws, {
+    ...message,
+    payload: {
+      ...message.payload,
+      sourceChannelId,
+    },
+  });
+
+  logger.info(
+    { type: message.type, sourceChannelId, targetChannelId, sessionId: message.sessionId },
+    "Forwarded RTC signaling message",
+  );
+}
+
 // ─── Broadcast ──────────────────────────────────────────────────────────────
+
+function resolveClientIdBySocket(
+  connectedClients: Map<string, ConnectedClient>,
+  ws: WebSocket,
+): string | null {
+  for (const [clientId, client] of connectedClients) {
+    if (client.ws === ws) return clientId;
+  }
+
+  return null;
+}
 
 /**
  * Broadcast an agent response to all clients subscribed to a given session.

--- a/packages/shared/src/types/protocol.ts
+++ b/packages/shared/src/types/protocol.ts
@@ -22,6 +22,10 @@ export const MessageTypeSchema = z.enum([
   "voice.audio.response",
   "voice.transcript",
   "voice.end",
+  "rtc.offer",
+  "rtc.answer",
+  "rtc.ice-candidate",
+  "rtc.hangup",
   "agent.handoff",
   "orchestration.status",
   "error",
@@ -59,6 +63,7 @@ export const ConnectAckMessageSchema = BaseMessageSchema.extend({
   type: z.literal("connect.ack"),
   payload: z.object({
     sessionId: z.string().min(1),
+    channelId: z.string().min(1),
     token: z.string().min(1),
     expiresAt: z.number().int().positive(),
   }),
@@ -233,6 +238,57 @@ export const VoiceEndMessageSchema = BaseMessageSchema.extend({
   payload: z.object({}).optional(),
 });
 
+// ─── WebRTC Signaling Messages ──────────────────────────────────────────────
+
+const RTCSessionDescriptionSchema = z.object({
+  type: z.enum(["offer", "answer"]),
+  sdp: z.string().min(1),
+});
+
+const RTCIceCandidateSchema = z.object({
+  candidate: z.string().min(1),
+  sdpMid: z.string().nullable().optional(),
+  sdpMLineIndex: z.number().int().nonnegative().nullable().optional(),
+  usernameFragment: z.string().nullable().optional(),
+});
+
+const RTCSignalPayloadBaseSchema = z.object({
+  targetChannelId: z.string().min(1),
+  sourceChannelId: z.string().min(1).optional(),
+});
+
+export const RTCOfferMessageSchema = BaseMessageSchema.extend({
+  type: z.literal("rtc.offer"),
+  payload: RTCSignalPayloadBaseSchema.extend({
+    description: RTCSessionDescriptionSchema.extend({
+      type: z.literal("offer"),
+    }),
+  }),
+});
+
+export const RTCAnswerMessageSchema = BaseMessageSchema.extend({
+  type: z.literal("rtc.answer"),
+  payload: RTCSignalPayloadBaseSchema.extend({
+    description: RTCSessionDescriptionSchema.extend({
+      type: z.literal("answer"),
+    }),
+  }),
+});
+
+export const RTCIceCandidateMessageSchema = BaseMessageSchema.extend({
+  type: z.literal("rtc.ice-candidate"),
+  payload: RTCSignalPayloadBaseSchema.extend({
+    candidate: RTCIceCandidateSchema,
+  }),
+});
+
+export const RTCHangupMessageSchema = BaseMessageSchema.extend({
+  type: z.literal("rtc.hangup"),
+  payload: RTCSignalPayloadBaseSchema.extend({
+    reason: z.string().min(1).optional(),
+  }),
+});
+
 // ─── Agent Handoff Messages ──────────────────────────────────────────────────
 
 export const AgentHandoffMessageSchema = BaseMessageSchema.extend({
@@ -297,6 +353,10 @@ export const ProtocolMessageSchema = z.discriminatedUnion("type", [
   VoiceAudioResponseMessageSchema,
   VoiceTranscriptMessageSchema,
   VoiceEndMessageSchema,
+  RTCOfferMessageSchema,
+  RTCAnswerMessageSchema,
+  RTCIceCandidateMessageSchema,
+  RTCHangupMessageSchema,
   AgentHandoffMessageSchema,
   OrchestrationStatusMessageSchema,
   ErrorMessageSchema,
@@ -324,6 +384,10 @@ export type VoiceAudioChunkMessage = z.infer<typeof VoiceAudioChunkMessageSchema
 export type VoiceAudioResponseMessage = z.infer<typeof VoiceAudioResponseMessageSchema>;
 export type VoiceTranscriptMessage = z.infer<typeof VoiceTranscriptMessageSchema>;
 export type VoiceEndMessage = z.infer<typeof VoiceEndMessageSchema>;
+export type RTCOfferMessage = z.infer<typeof RTCOfferMessageSchema>;
+export type RTCAnswerMessage = z.infer<typeof RTCAnswerMessageSchema>;
+export type RTCIceCandidateMessage = z.infer<typeof RTCIceCandidateMessageSchema>;
+export type RTCHangupMessage = z.infer<typeof RTCHangupMessageSchema>;
 export type AgentHandoffMessage = z.infer<typeof AgentHandoffMessageSchema>;
 export type OrchestrationStatusMessage = z.infer<typeof OrchestrationStatusMessageSchema>;
 export type ProtocolMessage = z.infer<typeof ProtocolMessageSchema>;

--- a/tests/gateway/websocket-protocol.test.ts
+++ b/tests/gateway/websocket-protocol.test.ts
@@ -1,5 +1,13 @@
 import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 import { SessionManager } from "../../gateway/src/session/manager.js";
+vi.mock("../../gateway/src/voice/handler.js", () => ({
+  handleVoiceStart: vi.fn(),
+  handleVoiceAudioChunk: vi.fn(),
+  handleVoiceEnd: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@karna/agent/orchestration/orchestrator.js", () => ({
+  Orchestrator: class {},
+}));
 import {
   handleMessage,
   resetProtocolTestState,
@@ -206,5 +214,110 @@ describe("gateway websocket protocol", () => {
 
     expect(appendToTranscript).toHaveBeenCalledTimes(2);
     expect(readTranscript).toHaveBeenCalledWith(session.id, 50);
+  });
+
+  it("relays rtc signaling messages to the requested peer and stamps sourceChannelId", async () => {
+    const sourceWs = createSocket();
+    const targetWs = createSocket();
+    const sourceSessionManager = new SessionManager({ flushIntervalMs: 300_000 });
+    const targetSessionManager = new SessionManager({ flushIntervalMs: 300_000 });
+    const sourceSession = sourceSessionManager.createSession("caller-web", "web", "user-1");
+    const targetSession = targetSessionManager.createSession("callee-mobile", "mobile", "user-1");
+
+    const connectedClients = new Map([
+      [
+        "caller-web",
+        {
+          ws: sourceWs as never,
+          auth: createAuthContext("caller-web", "operator", "token-a"),
+          sessionIds: new Set([sourceSession.id]),
+          lastSeen: Date.now(),
+        },
+      ],
+      [
+        "callee-mobile",
+        {
+          ws: targetWs as never,
+          auth: createAuthContext("callee-mobile", "operator", "token-b"),
+          sessionIds: new Set([targetSession.id]),
+          lastSeen: Date.now(),
+        },
+      ],
+    ]);
+
+    const context = createContext({
+      ws: sourceWs as never,
+      auth: createAuthContext("caller-web", "operator", "token-a"),
+      sessionManager: sourceSessionManager,
+      connectedClients,
+    });
+
+    await handleMessage(
+      sourceWs as never,
+      {
+        id: "msg-rtc-offer",
+        type: "rtc.offer",
+        timestamp: Date.now(),
+        sessionId: sourceSession.id,
+        payload: {
+          targetChannelId: "callee-mobile",
+          description: {
+            type: "offer",
+            sdp: "v=0\r\no=- 0 0 IN IP4 127.0.0.1",
+          },
+        },
+      },
+      context,
+    );
+
+    expect(sourceWs.sent).toHaveLength(0);
+    expect(targetWs.sent).toHaveLength(1);
+    expect(targetWs.sent[0]?.type).toBe("rtc.offer");
+    expect((targetWs.sent[0]?.payload as Record<string, unknown>)?.sourceChannelId).toBe("caller-web");
+    expect((targetWs.sent[0]?.payload as Record<string, unknown>)?.targetChannelId).toBe("callee-mobile");
+  });
+
+  it("returns an error when rtc signaling targets a disconnected peer", async () => {
+    const ws = createSocket();
+    const sessionManager = new SessionManager({ flushIntervalMs: 300_000 });
+    const session = sessionManager.createSession("caller-web", "web", "user-1");
+    const context = createContext({
+      ws: ws as never,
+      auth: createAuthContext("caller-web", "operator", "token-a"),
+      sessionManager,
+      connectedClients: new Map([
+        [
+          "caller-web",
+          {
+            ws: ws as never,
+            auth: createAuthContext("caller-web", "operator", "token-a"),
+            sessionIds: new Set([session.id]),
+            lastSeen: Date.now(),
+          },
+        ],
+      ]),
+    });
+
+    await handleMessage(
+      ws as never,
+      {
+        id: "msg-rtc-offer",
+        type: "rtc.offer",
+        timestamp: Date.now(),
+        sessionId: session.id,
+        payload: {
+          targetChannelId: "missing-peer",
+          description: {
+            type: "offer",
+            sdp: "v=0\r\no=- 0 0 IN IP4 127.0.0.1",
+          },
+        },
+      },
+      context,
+    );
+
+    expect(ws.sent).toHaveLength(1);
+    expect(ws.sent[0]?.type).toBe("error");
+    expect((ws.sent[0]?.payload as Record<string, unknown>)?.code).toBe("RTC_PEER_NOT_FOUND");
   });
 });

--- a/tests/shared/protocol-extended.test.ts
+++ b/tests/shared/protocol-extended.test.ts
@@ -7,6 +7,7 @@ import {
   ToolApprovalResponseMessageSchema,
   ToolResultMessageSchema,
   VoiceAudioChunkMessageSchema,
+  RTCIceCandidateMessageSchema,
   HeartbeatCheckMessageSchema,
   HeartbeatAckMessageSchema,
   SkillInvokeMessageSchema,
@@ -23,6 +24,7 @@ describe("Protocol Schema - Extended Coverage", () => {
       "tool.approval.requested", "tool.approval.response", "tool.result",
       "heartbeat.check", "heartbeat.ack",
       "status", "skill.invoke", "skill.result", "error",
+      "rtc.offer", "rtc.answer", "rtc.ice-candidate", "rtc.hangup",
     ];
 
     for (const type of validTypes) {
@@ -95,6 +97,27 @@ describe("Protocol Schema - Extended Coverage", () => {
       };
 
       expect(VoiceAudioChunkMessageSchema.safeParse(msg).success).toBe(true);
+    });
+  });
+
+  describe("RTCIceCandidateMessage", () => {
+    it("accepts an ICE candidate relay payload", () => {
+      const msg = {
+        id: "msg-rtc-ice-1",
+        type: "rtc.ice-candidate",
+        timestamp: Date.now(),
+        sessionId: "session-1",
+        payload: {
+          targetChannelId: "web-peer",
+          candidate: {
+            candidate: "candidate:1 1 UDP 2122260223 192.0.2.1 54400 typ host",
+            sdpMid: "0",
+            sdpMLineIndex: 0,
+          },
+        },
+      };
+
+      expect(RTCIceCandidateMessageSchema.safeParse(msg).success).toBe(true);
     });
   });
 

--- a/tests/shared/protocol.test.ts
+++ b/tests/shared/protocol.test.ts
@@ -9,6 +9,7 @@ import {
   ErrorMessageSchema,
   parseProtocolMessage,
   safeParseProtocolMessage,
+  RTCOfferMessageSchema,
 } from "../../packages/shared/src/types/protocol.js";
 
 describe("Protocol Schema", () => {
@@ -50,6 +51,26 @@ describe("Protocol Schema", () => {
         },
       };
       const result = ConnectMessageSchema.safeParse(msg);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("RTCOfferMessage", () => {
+    it("validates a WebRTC offer message", () => {
+      const msg = {
+        id: "msg-rtc-offer",
+        type: "rtc.offer",
+        timestamp: Date.now(),
+        sessionId: "session-1",
+        payload: {
+          targetChannelId: "mobile-1",
+          description: {
+            type: "offer",
+            sdp: "v=0\r\no=- 46117326 2 IN IP4 127.0.0.1",
+          },
+        },
+      };
+      const result = RTCOfferMessageSchema.safeParse(msg);
       expect(result.success).toBe(true);
     });
   });


### PR DESCRIPTION
## Summary
- add RTC offer, answer, ICE candidate, and hangup protocol messages
- relay RTC signaling through the gateway using stable per-client channel IDs
- stop web and mobile clients from reusing static channel IDs, and cover the new relay path with protocol tests

## Testing
- npm test -- --run tests/shared/protocol.test.ts tests/shared/protocol-extended.test.ts tests/gateway/websocket-protocol.test.ts

Refs #3