### PR TITLE
feat(web): add WebRTC voice session manager

### DIFF
--- a/apps/web/lib/webrtc.ts
+++ b/apps/web/lib/webrtc.ts
@@ -1,0 +1,292 @@
+import { getWSClient, type WSClient, type WSMessageHandler } from "./ws";
+
+export type RTCSignalType = "rtc.offer" | "rtc.answer" | "rtc.ice-candidate" | "rtc.hangup";
+
+type RTCSignalMessage = {
+  id?: string;
+  type: RTCSignalType;
+  timestamp?: number;
+  sessionId?: string;
+  payload?: Record<string, unknown>;
+};
+
+type RTCSignalDescription = {
+  type: "offer" | "answer";
+  sdp: string;
+};
+
+type RTCSignalCandidate = {
+  candidate: string;
+  sdpMid?: string | null;
+  sdpMLineIndex?: number | null;
+  usernameFragment?: string | null;
+};
+
+type RTCPeerConnectionLike = {
+  onicecandidate: ((event: { candidate: RTCIceCandidateInit | null }) => void) | null;
+  ontrack: ((event: { streams: MediaStream[] }) => void) | null;
+  onconnectionstatechange: (() => void) | null;
+  connectionState?: string;
+  addTrack(track: MediaStreamTrack, ...streams: MediaStream[]): void;
+  createOffer(): Promise<RTCSessionDescriptionInit>;
+  createAnswer(): Promise<RTCSessionDescriptionInit>;
+  setLocalDescription(description: RTCSessionDescriptionInit): Promise<void>;
+  setRemoteDescription(description: RTCSessionDescriptionInit): Promise<void>;
+  addIceCandidate(candidate?: RTCIceCandidateInit): Promise<void>;
+  close(): void;
+};
+
+type PeerConnectionFactory = () => RTCPeerConnectionLike;
+type GetUserMedia = (constraints: MediaStreamConstraints) => Promise<MediaStream>;
+
+export type WebRTCSessionState =
+  | "idle"
+  | "requesting-media"
+  | "negotiating"
+  | "connected"
+  | "ended"
+  | "error";
+
+export class WebRTCVoiceSession {
+  private ws: WSClient;
+  private createPeerConnection: PeerConnectionFactory;
+  private getUserMedia: GetUserMedia;
+  private peerConnection: RTCPeerConnectionLike | null = null;
+  private localStream: MediaStream | null = null;
+  private remoteStream: MediaStream | null = null;
+  private targetChannelId: string | null = null;
+  private state: WebRTCSessionState = "idle";
+  private stateHandlers = new Set<(state: WebRTCSessionState) => void>();
+  private remoteStreamHandlers = new Set<(stream: MediaStream) => void>();
+  private unsubscribeMessage: (() => void) | null = null;
+
+  constructor(options?: {
+    wsClient?: WSClient;
+    peerConnectionFactory?: PeerConnectionFactory;
+    getUserMedia?: GetUserMedia;
+  }) {
+    this.ws = options?.wsClient ?? getWSClient();
+    this.createPeerConnection =
+      options?.peerConnectionFactory ??
+      (() => new RTCPeerConnection({ iceServers: [{ urls: "stun:stun.l.google.com:19302" }] }));
+    this.getUserMedia =
+      options?.getUserMedia ??
+      ((constraints) => navigator.mediaDevices.getUserMedia(constraints));
+  }
+
+  get currentState(): WebRTCSessionState {
+    return this.state;
+  }
+
+  get currentTargetChannelId(): string | null {
+    return this.targetChannelId;
+  }
+
+  onStateChange(handler: (state: WebRTCSessionState) => void): () => void {
+    this.stateHandlers.add(handler);
+    return () => this.stateHandlers.delete(handler);
+  }
+
+  onRemoteStream(handler: (stream: MediaStream) => void): () => void {
+    this.remoteStreamHandlers.add(handler);
+    return () => this.remoteStreamHandlers.delete(handler);
+  }
+
+  async startCall(targetChannelId: string): Promise<void> {
+    this.targetChannelId = targetChannelId;
+    this.setState("requesting-media");
+    await this.ensurePeerConnection();
+
+    const offer = await this.peerConnection!.createOffer();
+    await this.peerConnection!.setLocalDescription(offer);
+    this.setState("negotiating");
+
+    this.sendSignal("rtc.offer", {
+      targetChannelId,
+      description: {
+        type: "offer",
+        sdp: offer.sdp ?? "",
+      },
+    });
+  }
+
+  async handleSignal(message: RTCSignalMessage): Promise<void> {
+    const payload = message.payload ?? {};
+
+    switch (message.type) {
+      case "rtc.offer":
+        await this.handleOffer(payload);
+        break;
+      case "rtc.answer":
+        await this.handleAnswer(payload);
+        break;
+      case "rtc.ice-candidate":
+        await this.handleIceCandidate(payload);
+        break;
+      case "rtc.hangup":
+        this.endCall(false);
+        break;
+    }
+  }
+
+  listen(): void {
+    if (this.unsubscribeMessage) return;
+
+    const handler: WSMessageHandler = (data) => {
+      const message = data as RTCSignalMessage;
+      if (!message?.type || !message.type.startsWith("rtc.")) return;
+      void this.handleSignal(message);
+    };
+
+    this.unsubscribeMessage = this.ws.onMessage(handler);
+  }
+
+  endCall(notifyPeer = true): void {
+    if (notifyPeer && this.targetChannelId) {
+      this.sendSignal("rtc.hangup", {
+        targetChannelId: this.targetChannelId,
+      });
+    }
+
+    this.peerConnection?.close();
+    this.peerConnection = null;
+    this.remoteStream = null;
+    this.targetChannelId = null;
+
+    if (this.localStream) {
+      this.localStream.getTracks().forEach((track) => track.stop());
+      this.localStream = null;
+    }
+
+    this.setState("ended");
+  }
+
+  destroy(): void {
+    this.endCall(false);
+    this.unsubscribeMessage?.();
+    this.unsubscribeMessage = null;
+    this.stateHandlers.clear();
+    this.remoteStreamHandlers.clear();
+  }
+
+  private async handleOffer(payload: Record<string, unknown>): Promise<void> {
+    const targetChannelId = payload.sourceChannelId;
+    const description = payload.description as RTCSignalDescription | undefined;
+
+    if (typeof targetChannelId !== "string" || !description?.sdp) {
+      throw new Error("Invalid RTC offer payload");
+    }
+
+    this.targetChannelId = targetChannelId;
+    this.setState("requesting-media");
+    await this.ensurePeerConnection();
+    await this.peerConnection!.setRemoteDescription(description);
+
+    const answer = await this.peerConnection!.createAnswer();
+    await this.peerConnection!.setLocalDescription(answer);
+    this.setState("negotiating");
+
+    this.sendSignal("rtc.answer", {
+      targetChannelId,
+      description: {
+        type: "answer",
+        sdp: answer.sdp ?? "",
+      },
+    });
+  }
+
+  private async handleAnswer(payload: Record<string, unknown>): Promise<void> {
+    const description = payload.description as RTCSignalDescription | undefined;
+    if (!description?.sdp || !this.peerConnection) {
+      throw new Error("Invalid RTC answer payload");
+    }
+
+    await this.peerConnection.setRemoteDescription(description);
+    this.setState("connected");
+  }
+
+  private async handleIceCandidate(payload: Record<string, unknown>): Promise<void> {
+    const candidate = payload.candidate as RTCSignalCandidate | undefined;
+    if (!candidate?.candidate || !this.peerConnection) return;
+
+    await this.peerConnection.addIceCandidate(candidate);
+  }
+
+  private async ensurePeerConnection(): Promise<void> {
+    if (this.peerConnection) return;
+
+    this.localStream = await this.getUserMedia({
+      audio: {
+        echoCancellation: true,
+        noiseSuppression: true,
+      },
+      video: false,
+    });
+
+    const peer = this.createPeerConnection();
+
+    this.localStream.getTracks().forEach((track) => {
+      peer.addTrack(track, this.localStream!);
+    });
+
+    peer.onicecandidate = (event) => {
+      if (!event.candidate || !this.targetChannelId) return;
+      this.sendSignal("rtc.ice-candidate", {
+        targetChannelId: this.targetChannelId,
+        candidate: {
+          candidate: event.candidate.candidate,
+          sdpMid: event.candidate.sdpMid,
+          sdpMLineIndex: event.candidate.sdpMLineIndex,
+          usernameFragment: event.candidate.usernameFragment,
+        },
+      });
+    };
+
+    peer.ontrack = (event) => {
+      const [stream] = event.streams;
+      if (!stream) return;
+      this.remoteStream = stream;
+      this.remoteStreamHandlers.forEach((handler) => handler(stream));
+      this.setState("connected");
+    };
+
+    peer.onconnectionstatechange = () => {
+      if (peer.connectionState === "connected") {
+        this.setState("connected");
+      } else if (
+        peer.connectionState === "disconnected" ||
+        peer.connectionState === "failed" ||
+        peer.connectionState === "closed"
+      ) {
+        this.setState("ended");
+      }
+    };
+
+    this.peerConnection = peer;
+  }
+
+  private sendSignal(type: RTCSignalType, payload: Record<string, unknown>): void {
+    this.ws.send({
+      id: crypto.randomUUID(),
+      type,
+      timestamp: Date.now(),
+      sessionId: this.ws.currentSessionId ?? undefined,
+      payload,
+    });
+  }
+
+  private setState(state: WebRTCSessionState): void {
+    this.state = state;
+    this.stateHandlers.forEach((handler) => handler(state));
+  }
+}
+
+let webRTCVoiceSessionInstance: WebRTCVoiceSession | null = null;
+
+export function getWebRTCVoiceSession(): WebRTCVoiceSession {
+  if (!webRTCVoiceSessionInstance) {
+    webRTCVoiceSessionInstance = new WebRTCVoiceSession();
+  }
+
+  return webRTCVoiceSessionInstance;
+}

--- a/tests/gateway/websocket-protocol.test.ts
+++ b/tests/gateway/websocket-protocol.test.ts
@@ -1,5 +1,13 @@
 import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 import { SessionManager } from "../../gateway/src/session/manager.js";
+vi.mock("../../gateway/src/voice/handler.js", () => ({
+  handleVoiceStart: vi.fn(),
+  handleVoiceAudioChunk: vi.fn(),
+  handleVoiceEnd: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@karna/agent/orchestration/orchestrator.js", () => ({
+  Orchestrator: class {},
+}));
 import {
   handleMessage,
   resetProtocolTestState,

--- a/tests/web/webrtc.test.ts
+++ b/tests/web/webrtc.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it, vi } from "vitest";
+import { WebRTCVoiceSession } from "../../apps/web/lib/webrtc.js";
+
+function createTrack(id: string) {
+  return {
+    id,
+    stop: vi.fn(),
+  };
+}
+
+function createStream(trackIds: string[]) {
+  const tracks = trackIds.map((id) => createTrack(id));
+  return {
+    tracks,
+    getTracks: () => tracks,
+  } as unknown as MediaStream;
+}
+
+function createPeerConnectionStub() {
+  const state = {
+    localDescription: null as RTCSessionDescriptionInit | null,
+    remoteDescription: null as RTCSessionDescriptionInit | null,
+    tracks: [] as Array<{ track: MediaStreamTrack; stream: MediaStream }>,
+    addedCandidates: [] as RTCIceCandidateInit[],
+  };
+
+  const peer = {
+    onicecandidate: null as ((event: { candidate: RTCIceCandidateInit | null }) => void) | null,
+    ontrack: null as ((event: { streams: MediaStream[] }) => void) | null,
+    onconnectionstatechange: null as (() => void) | null,
+    connectionState: "new",
+    addTrack: vi.fn((track: MediaStreamTrack, stream: MediaStream) => {
+      state.tracks.push({ track, stream });
+    }),
+    createOffer: vi.fn().mockResolvedValue({
+      type: "offer",
+      sdp: "offer-sdp",
+    } satisfies RTCSessionDescriptionInit),
+    createAnswer: vi.fn().mockResolvedValue({
+      type: "answer",
+      sdp: "answer-sdp",
+    } satisfies RTCSessionDescriptionInit),
+    setLocalDescription: vi.fn(async (description: RTCSessionDescriptionInit) => {
+      state.localDescription = description;
+    }),
+    setRemoteDescription: vi.fn(async (description: RTCSessionDescriptionInit) => {
+      state.remoteDescription = description;
+    }),
+    addIceCandidate: vi.fn(async (candidate?: RTCIceCandidateInit) => {
+      if (candidate) state.addedCandidates.push(candidate);
+    }),
+    close: vi.fn(() => {
+      peer.connectionState = "closed";
+    }),
+  };
+
+  return { peer, state };
+}
+
+describe("WebRTCVoiceSession", () => {
+  it("starts a call by creating an offer and sending rtc.offer", async () => {
+    const sent: unknown[] = [];
+    const wsClient = {
+      currentSessionId: "session-1",
+      send: vi.fn((message: unknown) => {
+        sent.push(message);
+      }),
+      onMessage: vi.fn(() => () => {}),
+    };
+    const stream = createStream(["track-1"]);
+    const { peer, state } = createPeerConnectionStub();
+    const session = new WebRTCVoiceSession({
+      wsClient: wsClient as never,
+      peerConnectionFactory: () => peer as never,
+      getUserMedia: vi.fn().mockResolvedValue(stream),
+    });
+
+    await session.startCall("mobile-peer");
+
+    expect(peer.addTrack).toHaveBeenCalledTimes(1);
+    expect(state.tracks[0]?.stream).toBe(stream);
+    expect(peer.createOffer).toHaveBeenCalledTimes(1);
+    expect(peer.setLocalDescription).toHaveBeenCalledWith({
+      type: "offer",
+      sdp: "offer-sdp",
+    });
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({
+      type: "rtc.offer",
+      sessionId: "session-1",
+      payload: {
+        targetChannelId: "mobile-peer",
+        description: {
+          type: "offer",
+          sdp: "offer-sdp",
+        },
+      },
+    });
+    expect(session.currentTargetChannelId).toBe("mobile-peer");
+  });
+
+  it("answers an incoming offer and sends rtc.answer back to the caller", async () => {
+    const sent: unknown[] = [];
+    const wsClient = {
+      currentSessionId: "session-2",
+      send: vi.fn((message: unknown) => {
+        sent.push(message);
+      }),
+      onMessage: vi.fn(() => () => {}),
+    };
+    const stream = createStream(["track-2"]);
+    const { peer } = createPeerConnectionStub();
+    const session = new WebRTCVoiceSession({
+      wsClient: wsClient as never,
+      peerConnectionFactory: () => peer as never,
+      getUserMedia: vi.fn().mockResolvedValue(stream),
+    });
+
+    await session.handleSignal({
+      type: "rtc.offer",
+      payload: {
+        sourceChannelId: "web-peer",
+        description: {
+          type: "offer",
+          sdp: "remote-offer",
+        },
+      },
+    });
+
+    expect(peer.setRemoteDescription).toHaveBeenCalledWith({
+      type: "offer",
+      sdp: "remote-offer",
+    });
+    expect(peer.createAnswer).toHaveBeenCalledTimes(1);
+    expect(sent[0]).toMatchObject({
+      type: "rtc.answer",
+      sessionId: "session-2",
+      payload: {
+        targetChannelId: "web-peer",
+        description: {
+          type: "answer",
+          sdp: "answer-sdp",
+        },
+      },
+    });
+    expect(session.currentTargetChannelId).toBe("web-peer");
+  });
+
+  it("adds remote ICE candidates to the peer connection", async () => {
+    const { peer } = createPeerConnectionStub();
+    const session = new WebRTCVoiceSession({
+      wsClient: {
+        currentSessionId: "session-3",
+        send: vi.fn(),
+        onMessage: vi.fn(() => () => {}),
+      } as never,
+      peerConnectionFactory: () => peer as never,
+      getUserMedia: vi.fn().mockResolvedValue(createStream(["track-3"])),
+    });
+
+    await session.startCall("mobile-peer");
+    await session.handleSignal({
+      type: "rtc.ice-candidate",
+      payload: {
+        candidate: {
+          candidate: "candidate:1 1 UDP 2122260223 192.0.2.1 54400 typ host",
+          sdpMid: "0",
+          sdpMLineIndex: 0,
+        },
+      },
+    });
+
+    expect(peer.addIceCandidate).toHaveBeenCalledWith({
+      candidate: "candidate:1 1 UDP 2122260223 192.0.2.1 54400 typ host",
+      sdpMid: "0",
+      sdpMLineIndex: 0,
+    });
+  });
+
+  it("forwards local ICE candidates over the signaling channel", async () => {
+    const sent: unknown[] = [];
+    const { peer } = createPeerConnectionStub();
+    const session = new WebRTCVoiceSession({
+      wsClient: {
+        currentSessionId: "session-4",
+        send: vi.fn((message: unknown) => {
+          sent.push(message);
+        }),
+        onMessage: vi.fn(() => () => {}),
+      } as never,
+      peerConnectionFactory: () => peer as never,
+      getUserMedia: vi.fn().mockResolvedValue(createStream(["track-4"])),
+    });
+
+    await session.startCall("mobile-peer");
+    peer.onicecandidate?.({
+      candidate: {
+        candidate: "candidate:2 1 UDP 2122260223 192.0.2.5 54401 typ host",
+        sdpMid: "0",
+        sdpMLineIndex: 0,
+        usernameFragment: "abc",
+      },
+    });
+
+    expect(sent.at(-1)).toMatchObject({
+      type: "rtc.ice-candidate",
+      payload: {
+        targetChannelId: "mobile-peer",
+        candidate: {
+          candidate: "candidate:2 1 UDP 2122260223 192.0.2.5 54401 typ host",
+          sdpMid: "0",
+          sdpMLineIndex: 0,
+          usernameFragment: "abc",
+        },
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a browser-side WebRTC voice session manager that can create offers, answer calls, relay ICE candidates, and emit remote streams
- cover the offer/answer/ICE flow with focused web tests
- keep the combined RTC test stack runnable from a fresh clone by mocking heavyweight gateway dependencies in the protocol harness

## Testing
- npm test -- --run tests/web/webrtc.test.ts tests/shared/protocol.test.ts tests/shared/protocol-extended.test.ts tests/gateway/websocket-protocol.test.ts

Refs #3