### PR TITLE
feat(mobile): add WebRTC signaling session manager

### DIFF
--- a/apps/mobile/lib/gateway-client.ts
+++ b/apps/mobile/lib/gateway-client.ts
@@ -126,6 +126,14 @@ class GatewayClient {
     return this.ws?.readyState ?? WebSocket.CLOSED;
   }
 
+  getCurrentSessionId(): string | null {
+    return this.sessionId;
+  }
+
+  getCurrentChannelId(): string {
+    return this.channelId;
+  }
+
   // ── Private ──────────────────────────────────────────────────────────────
 
   private establishConnection(): void {

--- a/apps/mobile/lib/webrtc.ts
+++ b/apps/mobile/lib/webrtc.ts
@@ -1,0 +1,297 @@
+import { gatewayClient } from './gateway-client';
+
+type ProtocolMessage = {
+  type: string;
+  id?: string;
+  timestamp?: number;
+  sessionId?: string;
+  payload?: Record<string, unknown>;
+};
+
+type SignalType = 'rtc.offer' | 'rtc.answer' | 'rtc.ice-candidate' | 'rtc.hangup';
+
+type SessionDescription = {
+  type: 'offer' | 'answer';
+  sdp: string;
+};
+
+type IceCandidate = {
+  candidate: string;
+  sdpMid?: string | null;
+  sdpMLineIndex?: number | null;
+  usernameFragment?: string | null;
+};
+
+type PeerConnectionLike = {
+  onicecandidate: ((event: { candidate: RTCIceCandidateInit | null }) => void) | null;
+  ontrack: ((event: { streams: MediaStream[] }) => void) | null;
+  onconnectionstatechange: (() => void) | null;
+  connectionState?: string;
+  addTrack(track: MediaStreamTrack, ...streams: MediaStream[]): void;
+  createOffer(): Promise<RTCSessionDescriptionInit>;
+  createAnswer(): Promise<RTCSessionDescriptionInit>;
+  setLocalDescription(description: RTCSessionDescriptionInit): Promise<void>;
+  setRemoteDescription(description: RTCSessionDescriptionInit): Promise<void>;
+  addIceCandidate(candidate?: RTCIceCandidateInit): Promise<void>;
+  close(): void;
+};
+
+type PeerFactory = () => PeerConnectionLike;
+type GetUserMedia = (constraints: MediaStreamConstraints) => Promise<MediaStream>;
+type GatewayLike = {
+  send(message: ProtocolMessage): void;
+  onMessage(handler: (message: ProtocolMessage) => void): () => void;
+  getCurrentSessionId(): string | null;
+};
+
+export type MobileWebRTCState =
+  | 'idle'
+  | 'requesting-media'
+  | 'negotiating'
+  | 'connected'
+  | 'ended'
+  | 'error';
+
+export class MobileWebRTCSession {
+  private gateway: GatewayLike;
+  private createPeerConnection: PeerFactory;
+  private getUserMedia: GetUserMedia;
+  private peerConnection: PeerConnectionLike | null = null;
+  private localStream: MediaStream | null = null;
+  private targetChannelId: string | null = null;
+  private unsubscribeMessage: (() => void) | null = null;
+  private state: MobileWebRTCState = 'idle';
+  private stateHandlers = new Set<(state: MobileWebRTCState) => void>();
+  private remoteStreamHandlers = new Set<(stream: MediaStream) => void>();
+
+  constructor(options?: {
+    gateway?: GatewayLike;
+    peerConnectionFactory?: PeerFactory;
+    getUserMedia?: GetUserMedia;
+  }) {
+    this.gateway = options?.gateway ?? gatewayClient;
+    this.createPeerConnection =
+      options?.peerConnectionFactory ??
+      (() =>
+        new RTCPeerConnection({
+          iceServers: [{ urls: 'stun:stun.l.google.com:19302' }],
+        }) as unknown as PeerConnectionLike);
+    this.getUserMedia =
+      options?.getUserMedia ??
+      ((constraints) => navigator.mediaDevices.getUserMedia(constraints));
+  }
+
+  get currentState(): MobileWebRTCState {
+    return this.state;
+  }
+
+  get currentTargetChannelId(): string | null {
+    return this.targetChannelId;
+  }
+
+  onStateChange(handler: (state: MobileWebRTCState) => void): () => void {
+    this.stateHandlers.add(handler);
+    return () => this.stateHandlers.delete(handler);
+  }
+
+  onRemoteStream(handler: (stream: MediaStream) => void): () => void {
+    this.remoteStreamHandlers.add(handler);
+    return () => this.remoteStreamHandlers.delete(handler);
+  }
+
+  listen(): void {
+    if (this.unsubscribeMessage) return;
+
+    this.unsubscribeMessage = this.gateway.onMessage((message) => {
+      if (!message.type.startsWith('rtc.')) return;
+      void this.handleSignal(message);
+    });
+  }
+
+  async startCall(targetChannelId: string): Promise<void> {
+    this.targetChannelId = targetChannelId;
+    this.setState('requesting-media');
+    await this.ensurePeerConnection();
+
+    const offer = await this.peerConnection!.createOffer();
+    await this.peerConnection!.setLocalDescription(offer);
+    this.setState('negotiating');
+
+    this.sendSignal('rtc.offer', {
+      targetChannelId,
+      description: {
+        type: 'offer',
+        sdp: offer.sdp ?? '',
+      },
+    });
+  }
+
+  async handleSignal(message: ProtocolMessage): Promise<void> {
+    const payload = message.payload ?? {};
+
+    switch (message.type) {
+      case 'rtc.offer':
+        await this.handleOffer(payload);
+        break;
+      case 'rtc.answer':
+        await this.handleAnswer(payload);
+        break;
+      case 'rtc.ice-candidate':
+        await this.handleIceCandidate(payload);
+        break;
+      case 'rtc.hangup':
+        this.endCall(false);
+        break;
+      default:
+        break;
+    }
+  }
+
+  endCall(notifyPeer = true): void {
+    if (notifyPeer && this.targetChannelId) {
+      this.sendSignal('rtc.hangup', {
+        targetChannelId: this.targetChannelId,
+      });
+    }
+
+    this.peerConnection?.close();
+    this.peerConnection = null;
+    this.targetChannelId = null;
+
+    if (this.localStream) {
+      this.localStream.getTracks().forEach((track) => track.stop());
+      this.localStream = null;
+    }
+
+    this.setState('ended');
+  }
+
+  destroy(): void {
+    this.endCall(false);
+    this.unsubscribeMessage?.();
+    this.unsubscribeMessage = null;
+    this.stateHandlers.clear();
+    this.remoteStreamHandlers.clear();
+  }
+
+  private async handleOffer(payload: Record<string, unknown>): Promise<void> {
+    const sourceChannelId = payload.sourceChannelId;
+    const description = payload.description as SessionDescription | undefined;
+
+    if (typeof sourceChannelId !== 'string' || !description?.sdp) {
+      throw new Error('Invalid RTC offer payload');
+    }
+
+    this.targetChannelId = sourceChannelId;
+    this.setState('requesting-media');
+    await this.ensurePeerConnection();
+    await this.peerConnection!.setRemoteDescription(description);
+
+    const answer = await this.peerConnection!.createAnswer();
+    await this.peerConnection!.setLocalDescription(answer);
+    this.setState('negotiating');
+
+    this.sendSignal('rtc.answer', {
+      targetChannelId: sourceChannelId,
+      description: {
+        type: 'answer',
+        sdp: answer.sdp ?? '',
+      },
+    });
+  }
+
+  private async handleAnswer(payload: Record<string, unknown>): Promise<void> {
+    const description = payload.description as SessionDescription | undefined;
+    if (!description?.sdp || !this.peerConnection) {
+      throw new Error('Invalid RTC answer payload');
+    }
+
+    await this.peerConnection.setRemoteDescription(description);
+    this.setState('connected');
+  }
+
+  private async handleIceCandidate(payload: Record<string, unknown>): Promise<void> {
+    const candidate = payload.candidate as IceCandidate | undefined;
+    if (!candidate?.candidate || !this.peerConnection) return;
+
+    await this.peerConnection.addIceCandidate(candidate);
+  }
+
+  private async ensurePeerConnection(): Promise<void> {
+    if (this.peerConnection) return;
+
+    this.localStream = await this.getUserMedia({
+      audio: {
+        echoCancellation: true,
+        noiseSuppression: true,
+      },
+      video: false,
+    });
+
+    const peer = this.createPeerConnection();
+
+    this.localStream.getTracks().forEach((track) => {
+      peer.addTrack(track, this.localStream!);
+    });
+
+    peer.onicecandidate = (event) => {
+      if (!event.candidate || !this.targetChannelId) return;
+
+      this.sendSignal('rtc.ice-candidate', {
+        targetChannelId: this.targetChannelId,
+        candidate: {
+          candidate: event.candidate.candidate,
+          sdpMid: event.candidate.sdpMid,
+          sdpMLineIndex: event.candidate.sdpMLineIndex,
+          usernameFragment: event.candidate.usernameFragment,
+        },
+      });
+    };
+
+    peer.ontrack = (event) => {
+      const [stream] = event.streams;
+      if (!stream) return;
+      this.remoteStreamHandlers.forEach((handler) => handler(stream));
+      this.setState('connected');
+    };
+
+    peer.onconnectionstatechange = () => {
+      if (peer.connectionState === 'connected') {
+        this.setState('connected');
+      } else if (
+        peer.connectionState === 'disconnected' ||
+        peer.connectionState === 'failed' ||
+        peer.connectionState === 'closed'
+      ) {
+        this.setState('ended');
+      }
+    };
+
+    this.peerConnection = peer;
+  }
+
+  private sendSignal(type: SignalType, payload: Record<string, unknown>): void {
+    this.gateway.send({
+      id: `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+      type,
+      timestamp: Date.now(),
+      sessionId: this.gateway.getCurrentSessionId() ?? undefined,
+      payload,
+    });
+  }
+
+  private setState(state: MobileWebRTCState): void {
+    this.state = state;
+    this.stateHandlers.forEach((handler) => handler(state));
+  }
+}
+
+let mobileWebRTCSessionInstance: MobileWebRTCSession | null = null;
+
+export function getMobileWebRTCSession(): MobileWebRTCSession {
+  if (!mobileWebRTCSessionInstance) {
+    mobileWebRTCSessionInstance = new MobileWebRTCSession();
+  }
+
+  return mobileWebRTCSessionInstance;
+}

--- a/tests/mobile/webrtc.test.ts
+++ b/tests/mobile/webrtc.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../apps/mobile/lib/gateway-client.js", () => ({
+  gatewayClient: {
+    send: vi.fn(),
+    onMessage: vi.fn(() => () => {}),
+    getCurrentSessionId: () => null,
+  },
+}));
+
+import { MobileWebRTCSession } from "../../apps/mobile/lib/webrtc.js";
+
+function createTrack(id: string) {
+  return {
+    id,
+    stop: vi.fn(),
+  };
+}
+
+function createStream(trackIds: string[]) {
+  const tracks = trackIds.map((id) => createTrack(id));
+  return {
+    tracks,
+    getTracks: () => tracks,
+  } as unknown as MediaStream;
+}
+
+function createPeerConnectionStub() {
+  const state = {
+    localDescription: null as RTCSessionDescriptionInit | null,
+    remoteDescription: null as RTCSessionDescriptionInit | null,
+    addedCandidates: [] as RTCIceCandidateInit[],
+    tracks: [] as Array<{ track: MediaStreamTrack; stream: MediaStream }>,
+  };
+
+  const peer = {
+    onicecandidate: null as ((event: { candidate: RTCIceCandidateInit | null }) => void) | null,
+    ontrack: null as ((event: { streams: MediaStream[] }) => void) | null,
+    onconnectionstatechange: null as (() => void) | null,
+    connectionState: "new",
+    addTrack: vi.fn((track: MediaStreamTrack, stream: MediaStream) => {
+      state.tracks.push({ track, stream });
+    }),
+    createOffer: vi.fn().mockResolvedValue({
+      type: "offer",
+      sdp: "mobile-offer",
+    } satisfies RTCSessionDescriptionInit),
+    createAnswer: vi.fn().mockResolvedValue({
+      type: "answer",
+      sdp: "mobile-answer",
+    } satisfies RTCSessionDescriptionInit),
+    setLocalDescription: vi.fn(async (description: RTCSessionDescriptionInit) => {
+      state.localDescription = description;
+    }),
+    setRemoteDescription: vi.fn(async (description: RTCSessionDescriptionInit) => {
+      state.remoteDescription = description;
+    }),
+    addIceCandidate: vi.fn(async (candidate?: RTCIceCandidateInit) => {
+      if (candidate) state.addedCandidates.push(candidate);
+    }),
+    close: vi.fn(() => {
+      peer.connectionState = "closed";
+    }),
+  };
+
+  return { peer, state };
+}
+
+describe("MobileWebRTCSession", () => {
+  it("starts a call and sends rtc.offer through the gateway client", async () => {
+    const sent: unknown[] = [];
+    const stream = createStream(["mobile-track-1"]);
+    const { peer, state } = createPeerConnectionStub();
+    const session = new MobileWebRTCSession({
+      gateway: {
+        send: vi.fn((message: unknown) => {
+          sent.push(message);
+        }),
+        onMessage: vi.fn(() => () => {}),
+        getCurrentSessionId: () => "session-mobile-1",
+      } as never,
+      peerConnectionFactory: () => peer as never,
+      getUserMedia: vi.fn().mockResolvedValue(stream),
+    });
+
+    await session.startCall("web-peer");
+
+    expect(peer.addTrack).toHaveBeenCalledTimes(1);
+    expect(state.tracks[0]?.stream).toBe(stream);
+    expect(sent[0]).toMatchObject({
+      type: "rtc.offer",
+      sessionId: "session-mobile-1",
+      payload: {
+        targetChannelId: "web-peer",
+        description: {
+          type: "offer",
+          sdp: "mobile-offer",
+        },
+      },
+    });
+  });
+
+  it("answers an incoming offer and sends rtc.answer", async () => {
+    const sent: unknown[] = [];
+    const { peer } = createPeerConnectionStub();
+    const session = new MobileWebRTCSession({
+      gateway: {
+        send: vi.fn((message: unknown) => {
+          sent.push(message);
+        }),
+        onMessage: vi.fn(() => () => {}),
+        getCurrentSessionId: () => "session-mobile-2",
+      } as never,
+      peerConnectionFactory: () => peer as never,
+      getUserMedia: vi.fn().mockResolvedValue(createStream(["mobile-track-2"])),
+    });
+
+    await session.handleSignal({
+      type: "rtc.offer",
+      payload: {
+        sourceChannelId: "web-peer",
+        description: {
+          type: "offer",
+          sdp: "offer-from-web",
+        },
+      },
+    });
+
+    expect(peer.setRemoteDescription).toHaveBeenCalledWith({
+      type: "offer",
+      sdp: "offer-from-web",
+    });
+    expect(sent[0]).toMatchObject({
+      type: "rtc.answer",
+      payload: {
+        targetChannelId: "web-peer",
+        description: {
+          type: "answer",
+          sdp: "mobile-answer",
+        },
+      },
+    });
+  });
+
+  it("subscribes to gateway rtc messages through listen()", async () => {
+    let messageHandler: ((message: unknown) => void) | null = null;
+    const sent: unknown[] = [];
+    const session = new MobileWebRTCSession({
+      gateway: {
+        send: vi.fn((message: unknown) => {
+          sent.push(message);
+        }),
+        onMessage: vi.fn((handler: (message: unknown) => void) => {
+          messageHandler = handler;
+          return () => {
+            messageHandler = null;
+          };
+        }),
+        getCurrentSessionId: () => "session-mobile-3",
+      } as never,
+      peerConnectionFactory: () => createPeerConnectionStub().peer as never,
+      getUserMedia: vi.fn().mockResolvedValue(createStream(["mobile-track-3"])),
+    });
+
+    session.listen();
+    messageHandler?.({
+      type: "rtc.offer",
+      payload: {
+        sourceChannelId: "web-peer",
+        description: {
+          type: "offer",
+          sdp: "offer-through-gateway",
+        },
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(sent[0]).toMatchObject({
+      type: "rtc.answer",
+      payload: {
+        targetChannelId: "web-peer",
+      },
+    });
+  });
+
+  it("sends rtc.hangup and stops tracks when ending a call", async () => {
+    const sent: unknown[] = [];
+    const stream = createStream(["mobile-track-4"]);
+    const { peer } = createPeerConnectionStub();
+    const session = new MobileWebRTCSession({
+      gateway: {
+        send: vi.fn((message: unknown) => {
+          sent.push(message);
+        }),
+        onMessage: vi.fn(() => () => {}),
+        getCurrentSessionId: () => "session-mobile-4",
+      } as never,
+      peerConnectionFactory: () => peer as never,
+      getUserMedia: vi.fn().mockResolvedValue(stream),
+    });
+
+    await session.startCall("web-peer");
+    session.endCall();
+
+    expect(sent.at(-1)).toMatchObject({
+      type: "rtc.hangup",
+      payload: {
+        targetChannelId: "web-peer",
+      },
+    });
+    expect(peer.close).toHaveBeenCalledTimes(1);
+    expect((stream as unknown as { tracks: Array<{ stop: ReturnType<typeof vi.fn> }> }).tracks[0]?.stop).toHaveBeenCalledTimes(1);
+    expect(session.currentState).toBe("ended");
+  });
+});


### PR DESCRIPTION
## Summary
- add a mobile-side WebRTC session manager that can create offers, answer calls, relay ICE candidates, and hang up through the gateway signaling channel
- expose current session and channel ids from the gateway client so mobile RTC signaling can stay aligned with the connected session
- cover the mobile RTC session flow with focused tests

## Testing
- pnpm --filter @karna/mobile typecheck
- npm test -- --run tests/mobile/webrtc.test.ts tests/web/webrtc.test.ts tests/shared/protocol.test.ts tests/shared/protocol-extended.test.ts tests/gateway/websocket-protocol.test.ts

Refs #3