### PR TITLE
feat(mobile): add live WebRTC voice controls

### DIFF
--- a/apps/mobile/components/VoiceInput.tsx
+++ b/apps/mobile/components/VoiceInput.tsx
@@ -14,6 +14,7 @@ import * as Haptics from 'expo-haptics';
 import { Feather } from '@expo/vector-icons';
 import { startRecording, stopRecording, getRecordingStatus } from '@/lib/voice';
 import { gatewayClient } from '@/lib/gateway-client';
+import { getMobileWebRTCSession, type MobileWebRTCState } from '@/lib/webrtc';
 import { useAppStore } from '@/lib/store';
 import { getColors, Spacing, BorderRadius } from '@/lib/theme';
 
@@ -21,8 +22,13 @@ export function VoiceInput() {
   const darkMode = useAppStore((s) => s.darkMode);
   const colors = getColors(darkMode ? 'dark' : 'light');
   const [recording, setRecording] = useState(false);
+  const [rtcState, setRtcState] = useState<MobileWebRTCState>('idle');
   const [audioLevel, setAudioLevel] = useState(0);
   const levelPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const rtcSessionRef = useRef(getMobileWebRTCSession());
+  const liveVoicePeerChannelId = process.env.EXPO_PUBLIC_VOICE_PEER_CHANNEL_ID;
+  const liveVoiceEnabled =
+    process.env.EXPO_PUBLIC_ENABLE_LIVE_VOICE === 'true' && Boolean(liveVoicePeerChannelId);
 
   const pulseScale = useSharedValue(1);
   const ringOpacity = useSharedValue(0);
@@ -71,10 +77,17 @@ export function VoiceInput() {
   }, [pulseScale, ringOpacity, ringScale]);
 
   useEffect(() => {
+    const rtc = rtcSessionRef.current;
+    const unsubscribe = rtc.onStateChange((state) => {
+      setRtcState(state);
+    });
+
     return () => {
       if (levelPollRef.current) {
         clearInterval(levelPollRef.current);
       }
+      rtc.endCall(false);
+      unsubscribe();
     };
   }, []);
 
@@ -116,11 +129,74 @@ export function VoiceInput() {
     }
   }, [recording, stopPulse]);
 
+  const handleLiveCallPress = useCallback(async () => {
+    if (!liveVoiceEnabled || !liveVoicePeerChannelId) return;
+
+    await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+    const rtc = rtcSessionRef.current;
+
+    if (rtcState === 'connected' || rtcState === 'requesting-media' || rtcState === 'negotiating') {
+      rtc.endCall();
+      return;
+    }
+
+    if (!rtc.isAvailable()) {
+      console.warn('[VoiceInput] Native WebRTC runtime is not available on this build');
+      setRtcState('error');
+      return;
+    }
+
+    try {
+      rtc.listen();
+      await rtc.startCall(liveVoicePeerChannelId);
+    } catch (err) {
+      console.warn('[VoiceInput] Failed to start live WebRTC call:', err);
+      setRtcState('error');
+    }
+  }, [liveVoiceEnabled, liveVoicePeerChannelId, rtcState]);
+
   const levelBarWidth = `${Math.round(audioLevel * 100)}%` as const;
+  const isRtcConnecting = rtcState === 'requesting-media' || rtcState === 'negotiating';
+  const isRtcConnected = rtcState === 'connected';
+  const showRtcBadge = liveVoiceEnabled || rtcState === 'error';
 
   return (
     <View style={styles.container}>
-      <View style={styles.buttonWrapper}>
+      <View style={styles.controlsRow}>
+        {showRtcBadge && (
+          <Pressable
+            onPress={handleLiveCallPress}
+            style={[
+              styles.liveButton,
+              {
+                backgroundColor: isRtcConnected
+                  ? colors.success
+                  : rtcState === 'error'
+                    ? colors.error
+                    : colors.surfaceAlt,
+                borderColor: isRtcConnected ? colors.success : colors.border,
+              },
+            ]}
+          >
+            <Feather
+              name={isRtcConnected || isRtcConnecting ? 'phone-off' : 'phone-call'}
+              size={16}
+              color={isRtcConnected ? '#FFFFFF' : colors.textSecondary}
+            />
+            <Text
+              style={[
+                styles.liveButtonText,
+                {
+                  color: isRtcConnected ? '#FFFFFF' : colors.textSecondary,
+                },
+              ]}
+            >
+              {isRtcConnected ? 'End' : isRtcConnecting ? 'Joining…' : 'Live Beta'}
+            </Text>
+          </Pressable>
+        )}
+
+        <View style={styles.buttonWrapper}>
         <Animated.View
           style={[
             styles.ring,
@@ -148,6 +224,7 @@ export function VoiceInput() {
             />
           </Pressable>
         </Animated.View>
+        </View>
       </View>
 
       {recording && (
@@ -173,6 +250,12 @@ export function VoiceInput() {
           </Text>
         </View>
       )}
+
+      {!recording && rtcState === 'error' && (
+        <Text style={[styles.recordingLabel, { color: colors.error, marginTop: Spacing.xs }]}>
+          Live voice requires a native WebRTC-enabled build.
+        </Text>
+      )}
     </View>
   );
 }
@@ -181,11 +264,29 @@ const styles = StyleSheet.create({
   container: {
     alignItems: 'center',
   },
+  controlsRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+  },
   buttonWrapper: {
     width: 48,
     height: 48,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  liveButton: {
+    minHeight: 36,
+    paddingHorizontal: Spacing.md,
+    borderRadius: BorderRadius.full,
+    borderWidth: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.xs,
+  },
+  liveButtonText: {
+    fontSize: 12,
+    fontWeight: '600',
   },
   ring: {
     position: 'absolute',

--- a/apps/mobile/lib/webrtc.ts
+++ b/apps/mobile/lib/webrtc.ts
@@ -78,7 +78,13 @@ export class MobileWebRTCSession {
         }) as unknown as PeerConnectionLike);
     this.getUserMedia =
       options?.getUserMedia ??
-      ((constraints) => navigator.mediaDevices.getUserMedia(constraints));
+      ((constraints) => {
+        const mediaDevices = globalThis.navigator?.mediaDevices;
+        if (!mediaDevices?.getUserMedia) {
+          throw new Error('Native WebRTC media support is not available');
+        }
+        return mediaDevices.getUserMedia(constraints);
+      });
   }
 
   get currentState(): MobileWebRTCState {
@@ -87,6 +93,13 @@ export class MobileWebRTCSession {
 
   get currentTargetChannelId(): string | null {
     return this.targetChannelId;
+  }
+
+  isAvailable(): boolean {
+    return (
+      typeof globalThis.RTCPeerConnection === 'function' &&
+      typeof globalThis.navigator?.mediaDevices?.getUserMedia === 'function'
+    );
   }
 
   onStateChange(handler: (state: MobileWebRTCState) => void): () => void {


### PR DESCRIPTION
## Summary
- wire the mobile voice input surface into the mobile WebRTC session manager as an opt-in live-call beta path
- guard the mobile WebRTC session against builds that do not yet include a native RTC runtime
- keep the existing press-to-record upload flow intact alongside the new live-call controls

## Testing
- pnpm --filter @karna/mobile typecheck
- npm test -- --run tests/mobile/webrtc.test.ts tests/web/webrtc.test.ts tests/shared/protocol.test.ts tests/shared/protocol-extended.test.ts tests/gateway/websocket-protocol.test.ts

Refs #3