### PR TITLE
feat(mobile): add live voice beta settings

### DIFF
--- a/apps/mobile/app/(tabs)/settings/index.tsx
+++ b/apps/mobile/app/(tabs)/settings/index.tsx
@@ -26,12 +26,20 @@ export default function SettingsScreen() {
   const setUrl = useAppStore((s) => s.setUrl);
   const token = useAppStore((s) => s.token);
   const setToken = useAppStore((s) => s.setToken);
+  const liveVoiceEnabled = useAppStore((s) => s.liveVoiceEnabled);
+  const setLiveVoiceEnabled = useAppStore((s) => s.setLiveVoiceEnabled);
+  const liveVoicePeerChannelId = useAppStore((s) => s.liveVoicePeerChannelId);
+  const setLiveVoicePeerChannelId = useAppStore(
+    (s) => s.setLiveVoicePeerChannelId,
+  );
   const connectionStatus = useAppStore((s) => s.status);
   const clearChat = useAppStore((s) => s.clearChat);
   const colors = getColors(darkMode ? 'dark' : 'light');
 
   const [editingUrl, setEditingUrl] = useState(url);
   const [editingToken, setEditingToken] = useState(token);
+  const [editingLiveVoicePeerChannelId, setEditingLiveVoicePeerChannelId] =
+    useState(liveVoicePeerChannelId);
 
   const handleSaveConnection = useCallback(() => {
     setUrl(editingUrl);
@@ -222,6 +230,81 @@ export default function SettingsScreen() {
               placeholder="Karna"
               placeholderTextColor={colors.textTertiary}
             />
+          </View>
+        </View>
+      </View>
+
+      {/* Live Voice Beta */}
+      <View style={styles.section}>
+        <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>
+          Live Voice Beta
+        </Text>
+        <View
+          style={[
+            styles.card,
+            { backgroundColor: colors.card, borderColor: colors.border },
+          ]}
+        >
+          <View style={styles.row}>
+            <View style={styles.rowLabel}>
+              <Feather name="radio" size={18} color={colors.textSecondary} />
+              <View>
+                <Text style={[styles.label, { color: colors.text }]}>
+                  Enable Live Voice
+                </Text>
+                <Text
+                  style={[
+                    styles.helpText,
+                    { color: colors.textSecondary },
+                  ]}
+                >
+                  Use WebRTC signaling for low-latency voice sessions.
+                </Text>
+              </View>
+            </View>
+            <Switch
+              value={liveVoiceEnabled}
+              onValueChange={(val) => {
+                setLiveVoiceEnabled(val);
+                Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+              }}
+              trackColor={{
+                false: colors.surfaceAlt,
+                true: colors.primary + '60',
+              }}
+              thumbColor={liveVoiceEnabled ? colors.primary : colors.textTertiary}
+            />
+          </View>
+
+          <View style={[styles.divider, { backgroundColor: colors.border }]} />
+
+          <View style={styles.inputRow}>
+            <Text style={[styles.inputLabel, { color: colors.textSecondary }]}>
+              Peer Channel ID
+            </Text>
+            <TextInput
+              style={[
+                styles.input,
+                {
+                  color: colors.text,
+                  backgroundColor: colors.inputBackground,
+                  borderColor: colors.border,
+                },
+              ]}
+              value={editingLiveVoicePeerChannelId}
+              onChangeText={(value) => {
+                setEditingLiveVoicePeerChannelId(value);
+                setLiveVoicePeerChannelId(value);
+              }}
+              placeholder="web-voice-peer"
+              placeholderTextColor={colors.textTertiary}
+              autoCapitalize="none"
+              autoCorrect={false}
+            />
+            <Text style={[styles.helpText, { color: colors.textSecondary }]}>
+              Set the target peer channel the mobile app should call during live
+              voice sessions.
+            </Text>
           </View>
         </View>
       </View>
@@ -420,6 +503,10 @@ const styles = StyleSheet.create({
     ...Typography.caption,
     fontWeight: '600',
     marginBottom: Spacing.xs,
+  },
+  helpText: {
+    ...Typography.caption,
+    marginTop: Spacing.xs,
   },
   input: {
     ...Typography.input,

--- a/apps/mobile/components/VoiceInput.tsx
+++ b/apps/mobile/components/VoiceInput.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
-import { View, StyleSheet, Pressable, Text } from 'react-native';
+import { View, StyleSheet, Pressable, Text, Alert } from 'react-native';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
@@ -20,19 +20,20 @@ import { getColors, Spacing, BorderRadius } from '@/lib/theme';
 
 export function VoiceInput() {
   const darkMode = useAppStore((s) => s.darkMode);
+  const liveVoiceEnabled = useAppStore((s) => s.liveVoiceEnabled);
+  const liveVoicePeerChannelId = useAppStore((s) => s.liveVoicePeerChannelId);
   const colors = getColors(darkMode ? 'dark' : 'light');
   const [recording, setRecording] = useState(false);
-  const [rtcState, setRtcState] = useState<MobileWebRTCState>('idle');
   const [audioLevel, setAudioLevel] = useState(0);
+  const [rtcState, setRtcState] = useState<MobileWebRTCState>('idle');
   const levelPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const rtcSessionRef = useRef(getMobileWebRTCSession());
-  const liveVoicePeerChannelId = process.env.EXPO_PUBLIC_VOICE_PEER_CHANNEL_ID;
-  const liveVoiceEnabled =
-    process.env.EXPO_PUBLIC_ENABLE_LIVE_VOICE === 'true' && Boolean(liveVoicePeerChannelId);
 
   const pulseScale = useSharedValue(1);
   const ringOpacity = useSharedValue(0);
   const ringScale = useSharedValue(1);
+  const isLiveCallConfigured =
+    liveVoiceEnabled && liveVoicePeerChannelId.trim().length > 0;
 
   const pulseAnimatedStyle = useAnimatedStyle(() => ({
     transform: [{ scale: pulseScale.value }],
@@ -78,6 +79,9 @@ export function VoiceInput() {
 
   useEffect(() => {
     const rtc = rtcSessionRef.current;
+    rtc.listen();
+    setRtcState(rtc.currentState);
+
     const unsubscribe = rtc.onStateChange((state) => {
       setRtcState(state);
     });
@@ -130,12 +134,22 @@ export function VoiceInput() {
   }, [recording, stopPulse]);
 
   const handleLiveCallPress = useCallback(async () => {
-    if (!liveVoiceEnabled || !liveVoicePeerChannelId) return;
+    if (!isLiveCallConfigured) {
+      Alert.alert(
+        'Live Voice Beta',
+        'Enable Live Voice Beta and set a peer channel ID in Settings first.',
+      );
+      return;
+    }
 
     await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
     const rtc = rtcSessionRef.current;
 
-    if (rtcState === 'connected' || rtcState === 'requesting-media' || rtcState === 'negotiating') {
+    if (
+      rtcState === 'connected' ||
+      rtcState === 'requesting-media' ||
+      rtcState === 'negotiating'
+    ) {
       rtc.endCall();
       return;
     }
@@ -143,88 +157,93 @@ export function VoiceInput() {
     if (!rtc.isAvailable()) {
       console.warn('[VoiceInput] Native WebRTC runtime is not available on this build');
       setRtcState('error');
+      Alert.alert(
+        'Live Voice Beta',
+        'Live voice requires a native WebRTC-enabled mobile build.',
+      );
       return;
     }
 
     try {
-      rtc.listen();
-      await rtc.startCall(liveVoicePeerChannelId);
-    } catch (err) {
-      console.warn('[VoiceInput] Failed to start live WebRTC call:', err);
+      await rtc.startCall(liveVoicePeerChannelId.trim());
+    } catch (error) {
+      console.warn('[VoiceInput] Failed to start live call:', error);
       setRtcState('error');
+      Alert.alert(
+        'Live Voice Beta',
+        'Could not start the live voice session on this build.',
+      );
     }
-  }, [liveVoiceEnabled, liveVoicePeerChannelId, rtcState]);
+  }, [isLiveCallConfigured, liveVoicePeerChannelId, rtcState]);
 
   const levelBarWidth = `${Math.round(audioLevel * 100)}%` as const;
-  const isRtcConnecting = rtcState === 'requesting-media' || rtcState === 'negotiating';
+  const isRtcConnecting =
+    rtcState === 'requesting-media' || rtcState === 'negotiating';
   const isRtcConnected = rtcState === 'connected';
   const showRtcBadge = liveVoiceEnabled || rtcState === 'error';
+  const liveButtonColor = isRtcConnected
+    ? colors.success
+    : rtcState === 'error'
+      ? colors.error
+      : isLiveCallConfigured
+        ? colors.surfaceAlt
+        : colors.border;
+  const liveLabelColor =
+    isRtcConnected ? '#FFFFFF' : isLiveCallConfigured ? colors.text : colors.textTertiary;
+  const liveStatusLabel = isRtcConnected
+    ? 'End'
+    : isRtcConnecting
+      ? 'Joining...'
+      : 'Live Beta';
 
   return (
     <View style={styles.container}>
       <View style={styles.controlsRow}>
+        <View style={styles.buttonWrapper}>
+          <Animated.View
+            style={[
+              styles.ring,
+              { borderColor: colors.primary },
+              ringAnimatedStyle,
+            ]}
+          />
+          <Animated.View style={pulseAnimatedStyle}>
+            <Pressable
+              onPressIn={handlePressIn}
+              onPressOut={handlePressOut}
+              style={[
+                styles.button,
+                {
+                  backgroundColor: recording ? colors.error : colors.primary,
+                },
+              ]}
+            >
+              <Feather name="mic" size={22} color="#FFFFFF" />
+            </Pressable>
+          </Animated.View>
+        </View>
+
         {showRtcBadge && (
           <Pressable
             onPress={handleLiveCallPress}
             style={[
               styles.liveButton,
               {
-                backgroundColor: isRtcConnected
-                  ? colors.success
-                  : rtcState === 'error'
-                    ? colors.error
-                    : colors.surfaceAlt,
+                backgroundColor: liveButtonColor,
                 borderColor: isRtcConnected ? colors.success : colors.border,
               },
             ]}
           >
             <Feather
-              name={isRtcConnected || isRtcConnecting ? 'phone-off' : 'phone-call'}
-              size={16}
-              color={isRtcConnected ? '#FFFFFF' : colors.textSecondary}
+              name={isRtcConnected || isRtcConnecting ? 'phone-off' : 'radio'}
+              size={18}
+              color={liveLabelColor}
             />
-            <Text
-              style={[
-                styles.liveButtonText,
-                {
-                  color: isRtcConnected ? '#FFFFFF' : colors.textSecondary,
-                },
-              ]}
-            >
-              {isRtcConnected ? 'End' : isRtcConnecting ? 'Joining…' : 'Live Beta'}
+            <Text style={[styles.liveButtonText, { color: liveLabelColor }]}>
+              {liveStatusLabel}
             </Text>
           </Pressable>
         )}
-
-        <View style={styles.buttonWrapper}>
-        <Animated.View
-          style={[
-            styles.ring,
-            { borderColor: colors.primary },
-            ringAnimatedStyle,
-          ]}
-        />
-        <Animated.View style={pulseAnimatedStyle}>
-          <Pressable
-            onPressIn={handlePressIn}
-            onPressOut={handlePressOut}
-            style={[
-              styles.button,
-              {
-                backgroundColor: recording
-                  ? colors.error
-                  : colors.primary,
-              },
-            ]}
-          >
-            <Feather
-              name={recording ? 'mic' : 'mic'}
-              size={22}
-              color="#FFFFFF"
-            />
-          </Pressable>
-        </Animated.View>
-        </View>
       </View>
 
       {recording && (
@@ -275,19 +294,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
-  liveButton: {
-    minHeight: 36,
-    paddingHorizontal: Spacing.md,
-    borderRadius: BorderRadius.full,
-    borderWidth: 1,
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.xs,
-  },
-  liveButtonText: {
-    fontSize: 12,
-    fontWeight: '600',
-  },
   ring: {
     position: 'absolute',
     width: 48,
@@ -301,6 +307,20 @@ const styles = StyleSheet.create({
     borderRadius: 22,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  liveButton: {
+    minHeight: 36,
+    paddingHorizontal: Spacing.md,
+    borderRadius: BorderRadius.full,
+    borderWidth: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: Spacing.xs,
+  },
+  liveButtonText: {
+    fontSize: 12,
+    fontWeight: '600',
   },
   levelContainer: {
     alignItems: 'center',

--- a/apps/mobile/lib/store.ts
+++ b/apps/mobile/lib/store.ts
@@ -11,6 +11,8 @@ interface PersistedState {
   agentName: string;
   url: string;
   token: string;
+  liveVoiceEnabled: boolean;
+  liveVoicePeerChannelId: string;
   messages: ChatMessage[];
   reminders: Reminder[];
   skills: Skill[];
@@ -22,6 +24,8 @@ const PERSIST_KEYS: (keyof PersistedState)[] = [
   'agentName',
   'url',
   'token',
+  'liveVoiceEnabled',
+  'liveVoicePeerChannelId',
   'messages',
   'reminders',
   'skills',
@@ -162,9 +166,13 @@ interface SettingsSlice {
   darkMode: boolean;
   notifications: boolean;
   agentName: string;
+  liveVoiceEnabled: boolean;
+  liveVoicePeerChannelId: string;
   setDarkMode: (enabled: boolean) => void;
   setNotifications: (enabled: boolean) => void;
   setAgentName: (name: string) => void;
+  setLiveVoiceEnabled: (enabled: boolean) => void;
+  setLiveVoicePeerChannelId: (channelId: string) => void;
 }
 
 type AppState = ConnectionSlice &
@@ -240,9 +248,14 @@ export const useAppStore = create<AppState>()((set) => ({
   darkMode: true,
   notifications: true,
   agentName: 'Karna',
+  liveVoiceEnabled: false,
+  liveVoicePeerChannelId: '',
   setDarkMode: (darkMode) => set({ darkMode }),
   setNotifications: (notifications) => set({ notifications }),
   setAgentName: (agentName) => set({ agentName }),
+  setLiveVoiceEnabled: (liveVoiceEnabled) => set({ liveVoiceEnabled }),
+  setLiveVoicePeerChannelId: (liveVoicePeerChannelId) =>
+    set({ liveVoicePeerChannelId }),
 }));
 
 // Persist on every state change (debounced)


### PR DESCRIPTION
## Summary
- persist live voice beta settings in the mobile store
- add a live voice beta section in mobile settings for the target peer channel
- expose a live-call entry point in the mobile voice input while keeping push-to-talk intact

## Testing
- pnpm --filter @karna/mobile typecheck
- npm test -- --run tests/mobile/webrtc.test.ts tests/web/webrtc.test.ts tests/shared/protocol.test.ts tests/shared/protocol-extended.test.ts tests/gateway/websocket-protocol.test.ts