### PR TITLE
feat(web): persist live voice beta settings

### DIFF
--- a/apps/web/app/dashboard/settings/page.tsx
+++ b/apps/web/app/dashboard/settings/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Save, Eye, EyeOff, Download, Upload, RefreshCw, CheckCircle2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/Badge";
+import { useVoiceSettingsStore } from "@/lib/store";
 
 interface SettingsState {
   gateway: {
@@ -79,6 +80,18 @@ export default function SettingsPage() {
   const [settings, setSettings] = useState<SettingsState>(defaultSettings);
   const [showApiKeys, setShowApiKeys] = useState<Record<string, boolean>>({});
   const [saved, setSaved] = useState(false);
+  const hydrated = useVoiceSettingsStore((s) => s.hydrated);
+  const hydrateVoiceSettings = useVoiceSettingsStore((s) => s.hydrateVoiceSettings);
+  const liveVoiceEnabled = useVoiceSettingsStore((s) => s.liveVoiceEnabled);
+  const setLiveVoiceEnabled = useVoiceSettingsStore((s) => s.setLiveVoiceEnabled);
+  const liveVoicePeerChannelId = useVoiceSettingsStore((s) => s.liveVoicePeerChannelId);
+  const setLiveVoicePeerChannelId = useVoiceSettingsStore(
+    (s) => s.setLiveVoicePeerChannelId,
+  );
+
+  useEffect(() => {
+    hydrateVoiceSettings();
+  }, [hydrateVoiceSettings]);
 
   const handleSave = () => {
     setSaved(true);
@@ -360,6 +373,46 @@ export default function SettingsPage() {
               className={inputClass}
             />
           </div>
+        </div>
+      </section>
+
+      {/* Live Voice Beta */}
+      <section className="rounded-xl border border-dark-700 bg-dark-800 p-5 space-y-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-base font-medium text-white">Live Voice Beta</h2>
+            <p className="text-sm text-dark-400 mt-1">
+              Configure the runtime WebRTC peer used by the web dashboard voice overlay.
+            </p>
+          </div>
+          <button
+            onClick={() => setLiveVoiceEnabled(!liveVoiceEnabled)}
+            className={cn(
+              "relative w-10 h-5 rounded-full transition-colors",
+              liveVoiceEnabled ? "bg-accent-600" : "bg-dark-600",
+            )}
+          >
+            <span
+              className={cn(
+                "absolute top-0.5 w-4 h-4 rounded-full bg-white transition-transform",
+                liveVoiceEnabled ? "left-5.5" : "left-0.5",
+              )}
+            />
+          </button>
+        </div>
+
+        <div>
+          <label className={labelClass}>Peer Channel ID</label>
+          <input
+            type="text"
+            value={hydrated ? liveVoicePeerChannelId : ""}
+            onChange={(e) => setLiveVoicePeerChannelId(e.target.value)}
+            className={inputClass}
+            placeholder="mobile-voice-peer"
+          />
+          <p className="text-xs text-dark-500 mt-2">
+            This is saved in the browser so you can change live voice peers without rebuilding the app.
+          </p>
         </div>
       </section>
     </div>

--- a/apps/web/components/VoiceOverlay.tsx
+++ b/apps/web/components/VoiceOverlay.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils";
 import { getVoiceClient, type VoiceMode, type VoiceState } from "@/lib/voice";
 import { getWSClient } from "@/lib/ws";
 import { getWebRTCVoiceSession, type WebRTCSessionState } from "@/lib/webrtc";
+import { useVoiceSettingsStore } from "@/lib/store";
 
 interface VoiceOverlayProps {
   open: boolean;
@@ -24,7 +25,14 @@ export function VoiceOverlay({ open, onClose, onTranscript }: VoiceOverlayProps)
   const voiceClientRef = useRef(getVoiceClient());
   const rtcSessionRef = useRef(getWebRTCVoiceSession());
   const remoteAudioRef = useRef<HTMLAudioElement | null>(null);
-  const rtcTargetChannelId = process.env.NEXT_PUBLIC_VOICE_PEER_CHANNEL_ID;
+  const hydrated = useVoiceSettingsStore((s) => s.hydrated);
+  const hydrateVoiceSettings = useVoiceSettingsStore((s) => s.hydrateVoiceSettings);
+  const liveVoiceEnabled = useVoiceSettingsStore((s) => s.liveVoiceEnabled);
+  const rtcTargetChannelId = useVoiceSettingsStore((s) => s.liveVoicePeerChannelId);
+
+  useEffect(() => {
+    hydrateVoiceSettings();
+  }, [hydrateVoiceSettings]);
 
   // Subscribe to voice client events
   useEffect(() => {
@@ -70,7 +78,7 @@ export function VoiceOverlay({ open, onClose, onTranscript }: VoiceOverlayProps)
   }, [open, onTranscript, voiceMode]);
 
   useEffect(() => {
-    if (!open || !rtcTargetChannelId) return;
+    if (!open || !liveVoiceEnabled || !rtcTargetChannelId) return;
 
     const rtc = rtcSessionRef.current;
     rtc.listen();
@@ -98,7 +106,7 @@ export function VoiceOverlay({ open, onClose, onTranscript }: VoiceOverlayProps)
       unsubState();
       unsubRemote();
     };
-  }, [open, rtcTargetChannelId]);
+  }, [open, liveVoiceEnabled, rtcTargetChannelId]);
 
   // Listen for voice.transcript and voice.audio.response messages from WS
   useEffect(() => {
@@ -168,7 +176,10 @@ export function VoiceOverlay({ open, onClose, onTranscript }: VoiceOverlayProps)
   }, [onClose]);
 
   const handleLiveCallClick = useCallback(() => {
-    if (!rtcTargetChannelId) return;
+    if (!liveVoiceEnabled || !rtcTargetChannelId) {
+      setStatusText("Configure Live Voice Beta in Settings first.");
+      return;
+    }
 
     const rtc = rtcSessionRef.current;
     if (rtcState === "connected" || rtcState === "requesting-media" || rtcState === "negotiating") {
@@ -181,7 +192,7 @@ export function VoiceOverlay({ open, onClose, onTranscript }: VoiceOverlayProps)
       setStatusText("Live call failed. Try again.");
       setRtcState("error");
     });
-  }, [rtcState, rtcTargetChannelId]);
+  }, [liveVoiceEnabled, rtcState, rtcTargetChannelId]);
 
   // Handle Escape key
   useEffect(() => {
@@ -249,7 +260,7 @@ export function VoiceOverlay({ open, onClose, onTranscript }: VoiceOverlayProps)
         {voiceMode === "continuous" ? "Continuous" : "Push to Talk"}
       </button>
 
-      {rtcTargetChannelId && (
+      {(liveVoiceEnabled || rtcState === "error") && hydrated && (
         <button
           onClick={handleLiveCallClick}
           disabled={isRecording || isProcessing}
@@ -257,13 +268,19 @@ export function VoiceOverlay({ open, onClose, onTranscript }: VoiceOverlayProps)
             "absolute top-4 left-44 flex items-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors",
             isRtcConnected
               ? "bg-green-600 text-white hover:bg-green-500"
+              : rtcState === "error"
+                ? "bg-red-600 text-white hover:bg-red-500"
               : "bg-dark-800 text-dark-300 hover:text-white",
             (isRecording || isProcessing) && "opacity-50 cursor-not-allowed",
           )}
           title="Start live voice call"
         >
           {isRtcConnected || isRtcConnecting ? <PhoneOff size={16} /> : <Phone size={16} />}
-          {isRtcConnected ? "End Live Call" : isRtcConnecting ? "Connecting..." : "Live Call Beta"}
+          {isRtcConnected
+            ? "End Live Call"
+            : isRtcConnecting
+              ? "Connecting..."
+              : "Live Call Beta"}
         </button>
       )}
 

--- a/apps/web/lib/store.ts
+++ b/apps/web/lib/store.ts
@@ -128,3 +128,75 @@ export const useDashboardStore = create<DashboardState>((set) => ({
   toggleSidebar: () => set((state) => ({ sidebarCollapsed: !state.sidebarCollapsed })),
   setSidebarCollapsed: (collapsed) => set({ sidebarCollapsed: collapsed }),
 }));
+
+// ─── Voice Settings Store ───────────────────────────────────────────────────
+
+const WEB_VOICE_SETTINGS_STORAGE_KEY = "karna:web:voice-settings";
+
+type StoredVoiceSettings = {
+  liveVoiceEnabled?: boolean;
+  liveVoicePeerChannelId?: string;
+};
+
+function readStoredVoiceSettings(): StoredVoiceSettings {
+  if (typeof window === "undefined") {
+    return {};
+  }
+
+  try {
+    const raw = window.localStorage.getItem(WEB_VOICE_SETTINGS_STORAGE_KEY);
+    if (!raw) return {};
+    return JSON.parse(raw) as StoredVoiceSettings;
+  } catch {
+    return {};
+  }
+}
+
+function writeStoredVoiceSettings(settings: StoredVoiceSettings): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.localStorage.setItem(
+    WEB_VOICE_SETTINGS_STORAGE_KEY,
+    JSON.stringify(settings),
+  );
+}
+
+interface VoiceSettingsState {
+  hydrated: boolean;
+  liveVoiceEnabled: boolean;
+  liveVoicePeerChannelId: string;
+  hydrateVoiceSettings: () => void;
+  setLiveVoiceEnabled: (enabled: boolean) => void;
+  setLiveVoicePeerChannelId: (channelId: string) => void;
+}
+
+export const useVoiceSettingsStore = create<VoiceSettingsState>((set, get) => ({
+  hydrated: false,
+  liveVoiceEnabled: false,
+  liveVoicePeerChannelId: "",
+  hydrateVoiceSettings: () => {
+    if (get().hydrated) return;
+    const stored = readStoredVoiceSettings();
+    set({
+      hydrated: true,
+      liveVoiceEnabled: stored.liveVoiceEnabled ?? false,
+      liveVoicePeerChannelId: stored.liveVoicePeerChannelId ?? "",
+    });
+  },
+  setLiveVoiceEnabled: (enabled) => {
+    set({ liveVoiceEnabled: enabled });
+    writeStoredVoiceSettings({
+      liveVoiceEnabled: enabled,
+      liveVoicePeerChannelId: get().liveVoicePeerChannelId,
+    });
+  },
+  setLiveVoicePeerChannelId: (channelId) => {
+    set({ liveVoicePeerChannelId: channelId });
+    writeStoredVoiceSettings({
+      liveVoiceEnabled: get().liveVoiceEnabled,
+      liveVoicePeerChannelId: channelId,
+    });
+  },
+}));


### PR DESCRIPTION
## Summary
- add a persisted web voice settings store for live voice beta config
- expose live voice beta settings on the dashboard settings page
- switch the web voice overlay from build-time env vars to runtime settings

## Testing
- pnpm --filter @karna/web typecheck
- npm test -- --run tests/mobile/webrtc.test.ts tests/web/webrtc.test.ts tests/shared/protocol.test.ts tests/shared/protocol-extended.test.ts tests/gateway/websocket-protocol.test.ts