### PR TITLE
fix(webrtc): surface rtc signaling errors

### DIFF
--- a/apps/mobile/app/(tabs)/chat/index.tsx
+++ b/apps/mobile/app/(tabs)/chat/index.tsx
@@ -14,6 +14,7 @@ import { Feather } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
 import { useAppStore, type ChatMessage } from '@/lib/store';
 import { gatewayClient } from '@/lib/gateway-client';
+import type { MobileWebRTCState } from '@/lib/webrtc';
 import { getColors, Typography, Spacing, BorderRadius } from '@/lib/theme';
 import { ChatBubble } from '@/components/ChatBubble';
 import { TypingIndicator } from '@/components/TypingIndicator';
@@ -27,6 +28,7 @@ export default function ChatScreen() {
   const colors = getColors(darkMode ? 'dark' : 'light');
 
   const [inputText, setInputText] = useState('');
+  const [liveVoiceState, setLiveVoiceState] = useState<MobileWebRTCState>('idle');
   const flatListRef = useRef<FlatList<ChatMessage>>(null);
 
   const handleSend = useCallback(async () => {
@@ -73,6 +75,23 @@ export default function ChatScreen() {
         : connectionStatus === 'error'
           ? 'Connection Error'
           : 'Disconnected';
+  const showLiveVoiceBanner =
+    liveVoiceState === 'requesting-media' ||
+    liveVoiceState === 'negotiating' ||
+    liveVoiceState === 'connected' ||
+    liveVoiceState === 'error';
+  const liveVoiceBannerColor =
+    liveVoiceState === 'connected'
+      ? colors.success
+      : liveVoiceState === 'error'
+        ? colors.error
+        : colors.warning;
+  const liveVoiceBannerLabel =
+    liveVoiceState === 'connected'
+      ? 'Live voice active'
+      : liveVoiceState === 'error'
+        ? 'Live voice unavailable on this build'
+        : 'Connecting live voice...';
 
   return (
     <KeyboardAvoidingView
@@ -91,6 +110,22 @@ export default function ChatScreen() {
           <View style={[styles.statusDot, { backgroundColor: statusColor }]} />
           <Text style={[styles.statusText, { color: statusColor }]}>
             {statusLabel}
+          </Text>
+        </View>
+      )}
+
+      {showLiveVoiceBanner && (
+        <View
+          style={[
+            styles.statusBar,
+            { backgroundColor: liveVoiceBannerColor + '20' },
+          ]}
+        >
+          <View
+            style={[styles.statusDot, { backgroundColor: liveVoiceBannerColor }]}
+          />
+          <Text style={[styles.statusText, { color: liveVoiceBannerColor }]}>
+            {liveVoiceBannerLabel}
           </Text>
         </View>
       )}
@@ -169,7 +204,7 @@ export default function ChatScreen() {
               <Feather name="send" size={18} color="#FFFFFF" />
             </Pressable>
           ) : (
-            <VoiceInput />
+            <VoiceInput onLiveStateChange={setLiveVoiceState} />
           )}
         </View>
       </View>

--- a/apps/mobile/components/VoiceInput.tsx
+++ b/apps/mobile/components/VoiceInput.tsx
@@ -24,7 +24,11 @@ import { getColors, Spacing, BorderRadius } from '@/lib/theme';
 
 type MobileVoiceMode = 'push-to-talk' | 'continuous';
 
-export function VoiceInput() {
+interface VoiceInputProps {
+  onLiveStateChange?: (state: MobileWebRTCState) => void;
+}
+
+export function VoiceInput({ onLiveStateChange }: VoiceInputProps) {
   const darkMode = useAppStore((s) => s.darkMode);
   const liveVoiceEnabled = useAppStore((s) => s.liveVoiceEnabled);
   const liveVoicePeerChannelId = useAppStore((s) => s.liveVoicePeerChannelId);
@@ -89,9 +93,11 @@ export function VoiceInput() {
     const rtc = rtcSessionRef.current;
     rtc.listen();
     setRtcState(rtc.currentState);
+    onLiveStateChange?.(rtc.currentState);
 
     const unsubscribe = rtc.onStateChange((state) => {
       setRtcState(state);
+      onLiveStateChange?.(state);
     });
 
     return () => {
@@ -102,7 +108,7 @@ export function VoiceInput() {
       rtc.endCall(false);
       unsubscribe();
     };
-  }, []);
+  }, [onLiveStateChange]);
 
   const finishRecording = useCallback(async () => {
     if (!recording) return;

--- a/apps/mobile/lib/webrtc.ts
+++ b/apps/mobile/lib/webrtc.ts
@@ -8,6 +8,14 @@ type ProtocolMessage = {
   payload?: Record<string, unknown>;
 };
 
+type ProtocolErrorMessage = {
+  type: "error";
+  payload?: {
+    code?: string;
+    message?: string;
+  };
+};
+
 type SignalType = 'rtc.offer' | 'rtc.answer' | 'rtc.ice-candidate' | 'rtc.hangup';
 
 type SessionDescription = {
@@ -116,6 +124,15 @@ export class MobileWebRTCSession {
     if (this.unsubscribeMessage) return;
 
     this.unsubscribeMessage = this.gateway.onMessage((message) => {
+      const maybeError = message as ProtocolErrorMessage;
+      if (maybeError.type === 'error') {
+        const code = maybeError.payload?.code;
+        if (typeof code === 'string' && code.startsWith('RTC_')) {
+          this.setState('error');
+        }
+        return;
+      }
+
       if (!message.type.startsWith('rtc.')) return;
       void this.handleSignal(message);
     });

--- a/apps/web/lib/webrtc.ts
+++ b/apps/web/lib/webrtc.ts
@@ -10,6 +10,14 @@ type RTCSignalMessage = {
   payload?: Record<string, unknown>;
 };
 
+type RTCErrorMessage = {
+  type: "error";
+  payload?: {
+    code?: string;
+    message?: string;
+  };
+};
+
 type RTCSignalDescription = {
   type: "offer" | "answer";
   sdp: string;
@@ -136,8 +144,18 @@ export class WebRTCVoiceSession {
     if (this.unsubscribeMessage) return;
 
     const handler: WSMessageHandler = (data) => {
-      const message = data as RTCSignalMessage;
-      if (!message?.type || !message.type.startsWith("rtc.")) return;
+      const message = data as RTCSignalMessage | RTCErrorMessage;
+      if (!message?.type) return;
+
+      if (message.type === "error") {
+        const code = message.payload?.code;
+        if (typeof code === "string" && code.startsWith("RTC_")) {
+          this.setState("error");
+        }
+        return;
+      }
+
+      if (!message.type.startsWith("rtc.")) return;
       void this.handleSignal(message);
     };
 

--- a/gateway/src/protocol/handler.ts
+++ b/gateway/src/protocol/handler.ts
@@ -687,6 +687,12 @@ async function handleRTCSignal(
 
   const sourceChannelId = resolveClientIdBySocket(context.connectedClients, ws) ?? context.auth.channelId;
   const targetChannelId = message.payload.targetChannelId;
+
+  if (targetChannelId === sourceChannelId) {
+    sendError(ws, "RTC_INVALID_TARGET", "Cannot start a live voice session with the same channel");
+    return;
+  }
+
   const targetClient = context.connectedClients.get(targetChannelId);
 
   if (!targetClient || targetClient.ws.readyState !== targetClient.ws.OPEN) {

--- a/tests/gateway/websocket-protocol.test.ts
+++ b/tests/gateway/websocket-protocol.test.ts
@@ -320,4 +320,48 @@ describe("gateway websocket protocol", () => {
     expect(ws.sent[0]?.type).toBe("error");
     expect((ws.sent[0]?.payload as Record<string, unknown>)?.code).toBe("RTC_PEER_NOT_FOUND");
   });
+
+  it("rejects rtc signaling that targets the same channel", async () => {
+    const ws = createSocket();
+    const sessionManager = new SessionManager({ flushIntervalMs: 300_000 });
+    const session = sessionManager.createSession("caller-web", "web", "user-1");
+    const context = createContext({
+      ws: ws as never,
+      auth: createAuthContext("caller-web", "operator", "token-a"),
+      sessionManager,
+      connectedClients: new Map([
+        [
+          "caller-web",
+          {
+            ws: ws as never,
+            auth: createAuthContext("caller-web", "operator", "token-a"),
+            sessionIds: new Set([session.id]),
+            lastSeen: Date.now(),
+          },
+        ],
+      ]),
+    });
+
+    await handleMessage(
+      ws as never,
+      {
+        id: "msg-rtc-self",
+        type: "rtc.offer",
+        timestamp: Date.now(),
+        sessionId: session.id,
+        payload: {
+          targetChannelId: "caller-web",
+          description: {
+            type: "offer",
+            sdp: "v=0\r\no=- 0 0 IN IP4 127.0.0.1",
+          },
+        },
+      },
+      context,
+    );
+
+    expect(ws.sent).toHaveLength(1);
+    expect(ws.sent[0]?.type).toBe("error");
+    expect((ws.sent[0]?.payload as Record<string, unknown>)?.code).toBe("RTC_INVALID_TARGET");
+  });
 });

--- a/tests/mobile/webrtc.test.ts
+++ b/tests/mobile/webrtc.test.ts
@@ -242,4 +242,39 @@ describe("MobileWebRTCSession", () => {
     expect(session.currentState).toBe("connected");
     expect(states).toContain("connected");
   });
+
+  it("transitions to error when the gateway returns an RTC error", async () => {
+    let messageHandler: ((message: unknown) => void) | null = null;
+    const session = new MobileWebRTCSession({
+      gateway: {
+        send: vi.fn(),
+        onMessage: vi.fn((handler: (message: unknown) => void) => {
+          messageHandler = handler;
+          return () => {
+            messageHandler = null;
+          };
+        }),
+        getCurrentSessionId: () => "session-mobile-6",
+      } as never,
+      peerConnectionFactory: () => createPeerConnectionStub().peer as never,
+      getUserMedia: vi.fn().mockResolvedValue(createStream(["mobile-track-6"])),
+    });
+
+    const states: string[] = [];
+    session.onStateChange((state) => {
+      states.push(state);
+    });
+
+    session.listen();
+    messageHandler?.({
+      type: "error",
+      payload: {
+        code: "RTC_INVALID_TARGET",
+        message: "Cannot start a live voice session with the same channel",
+      },
+    });
+
+    expect(session.currentState).toBe("error");
+    expect(states).toContain("error");
+  });
 });

--- a/tests/web/webrtc.test.ts
+++ b/tests/web/webrtc.test.ts
@@ -318,4 +318,39 @@ describe("WebRTCVoiceSession", () => {
     expect(session.currentState).toBe("connected");
     expect(states).toContain("connected");
   });
+
+  it("transitions to error when the gateway returns an RTC error", async () => {
+    let messageHandler: ((message: unknown) => void) | null = null;
+    const session = new WebRTCVoiceSession({
+      wsClient: {
+        currentSessionId: "session-8",
+        send: vi.fn(),
+        onMessage: vi.fn((handler: (message: unknown) => void) => {
+          messageHandler = handler;
+          return () => {
+            messageHandler = null;
+          };
+        }),
+      } as never,
+      peerConnectionFactory: () => createPeerConnectionStub().peer as never,
+      getUserMedia: vi.fn().mockResolvedValue(createStream(["track-8"])),
+    });
+
+    const states: string[] = [];
+    session.onStateChange((state) => {
+      states.push(state);
+    });
+
+    session.listen();
+    messageHandler?.({
+      type: "error",
+      payload: {
+        code: "RTC_PEER_NOT_FOUND",
+        message: "Target peer is not connected",
+      },
+    });
+
+    expect(session.currentState).toBe("error");
+    expect(states).toContain("error");
+  });
 });


### PR DESCRIPTION
## Summary
- surface gateway RTC errors as real WebRTC session errors in both web and mobile clients
- reject self-targeted RTC calls at the gateway with a dedicated validation error
- add regression coverage for gateway validation and client-side RTC error state transitions

## Testing
- npm test -- --run tests/mobile/webrtc.test.ts tests/web/webrtc.test.ts tests/gateway/websocket-protocol.test.ts tests/shared/protocol.test.ts tests/shared/protocol-extended.test.ts
- pnpm --filter @karna/mobile typecheck
- pnpm --filter @karna/web typecheck