### PR TITLE
Fix chat hydration error and surface disconnected gateway

### DIFF
--- a/apps/web/app/chat/layout.tsx
+++ b/apps/web/app/chat/layout.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { mapGatewaySessionToChatSession } from "@/lib/chat";
-import { cn, formatRelativeTime, truncate } from "@/lib/utils";
+import { cn, truncate } from "@/lib/utils";
 import { useChatStore } from "@/lib/store";
 import { getWSClient } from "@/lib/ws";
 import { Plus, MessageSquare, Search, PanelLeftClose, PanelLeft } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
+import { RelativeTime } from "@/components/RelativeTime";
 
 function SessionSidebar({
   open,
@@ -115,7 +116,7 @@ function SessionSidebar({
                     {truncate(session.title, 30)}
                   </p>
                   <p className="text-xs text-dark-500 mt-0.5">
-                    {formatRelativeTime(session.updatedAt)}
+                    <RelativeTime timestamp={session.updatedAt} />
                     {session.messageCount > 0 && ` \u00b7 ${session.messageCount} msgs`}
                   </p>
                 </div>

--- a/apps/web/app/chat/page.tsx
+++ b/apps/web/app/chat/page.tsx
@@ -257,6 +257,10 @@ export default function ChatPage() {
   const handleSend = () => {
     const content = input.trim();
     if (!content || agentState === "thinking" || agentState === "streaming") return;
+    // Guard: if the gateway isn't connected we'd otherwise leave the user
+    // stuck on an optimistic "Thinking..." state forever with no indication
+    // of why nothing is happening.
+    if (wsState !== "connected") return;
 
     const msg: ChatMessageUI = {
       id: `user-${Date.now()}`,
@@ -329,6 +333,22 @@ export default function ChatPage() {
         </div>
       </div>
 
+      {/* Disconnected banner — surface why sends may be silently dropped */}
+      {wsState !== "connected" && (
+        <div className="bg-yellow-500/10 border-b border-yellow-500/30 px-4 py-2 flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-3">
+          <span className="text-yellow-400 text-sm font-medium">
+            {wsState === "connecting" ? "Connecting to gateway\u2026" : "Gateway not connected"}
+          </span>
+          <span className="text-yellow-400/70 text-xs sm:text-sm">
+            Start it locally with{" "}
+            <code className="bg-dark-700 px-1.5 py-0.5 rounded text-xs">pnpm gateway:dev</code>
+            {" "}or set{" "}
+            <code className="bg-dark-700 px-1.5 py-0.5 rounded text-xs">NEXT_PUBLIC_WS_URL</code>
+            .
+          </span>
+        </div>
+      )}
+
       {/* Messages */}
       <div className="flex-1 overflow-y-auto">
         {messages.length === 0 ? (
@@ -397,14 +417,22 @@ export default function ChatPage() {
           </button>
           <button
             onClick={handleSend}
-            disabled={!input.trim() || agentState === "thinking" || agentState === "streaming"}
+            disabled={
+              !input.trim() ||
+              agentState === "thinking" ||
+              agentState === "streaming" ||
+              wsState !== "connected"
+            }
             className={cn(
               "p-2.5 rounded-lg transition-colors shrink-0",
-              input.trim() && agentState !== "thinking" && agentState !== "streaming"
+              input.trim() &&
+                agentState !== "thinking" &&
+                agentState !== "streaming" &&
+                wsState === "connected"
                 ? "bg-accent-600 text-white hover:bg-accent-500 active:scale-95"
                 : "bg-dark-700 text-dark-500 cursor-not-allowed",
             )}
-            title="Send message"
+            title={wsState === "connected" ? "Send message" : "Gateway not connected"}
           >
             {agentState === "thinking" || agentState === "streaming" ? (
               <Loader2 size={18} className="animate-spin" />

--- a/apps/web/components/ChatMessage.tsx
+++ b/apps/web/components/ChatMessage.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { cn, formatRelativeTime } from "@/lib/utils";
+import { cn } from "@/lib/utils";
 import { User, Bot, ChevronDown, ChevronRight, Wrench } from "lucide-react";
 import { useState } from "react";
 import type { ChatMessageUI, ToolCallUI } from "@/lib/store";
 import { Badge } from "./Badge";
+import { RelativeTime } from "./RelativeTime";
 
 interface ChatMessageProps {
   message: ChatMessageUI;
@@ -146,7 +147,7 @@ export function ChatMessage({ message, onToolApproval }: ChatMessageProps) {
 
         {/* Timestamp */}
         <span className="text-xs text-dark-500 mt-1 px-1">
-          {formatRelativeTime(message.timestamp)}
+          <RelativeTime timestamp={message.timestamp} />
           {message.metadata?.model && (
             <span className="ml-2 text-dark-600">{message.metadata.model}</span>
           )}

--- a/apps/web/components/RelativeTime.tsx
+++ b/apps/web/components/RelativeTime.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { formatRelativeTime } from "@/lib/utils";
+
+/**
+ * Render a relative timestamp (e.g. "less than a minute ago") without
+ * triggering a React hydration mismatch.
+ *
+ * `formatDistanceToNow` depends on the current clock, so the value rendered
+ * on the server at prerender time will almost always differ from the value
+ * the client computes at hydration time. That produces React error #418
+ * ("text content did not match"). Rendering a stable placeholder until the
+ * component has mounted on the client avoids the mismatch.
+ */
+export function RelativeTime({
+  timestamp,
+  fallback = "",
+  className,
+}: {
+  timestamp: number;
+  fallback?: string;
+  className?: string;
+}) {
+  const [mounted, setMounted] = useState(false);
+  const [label, setLabel] = useState(fallback);
+
+  useEffect(() => {
+    setMounted(true);
+    setLabel(formatRelativeTime(timestamp));
+
+    // Refresh every 30s so "less than a minute ago" eventually ticks over.
+    const timer = setInterval(() => {
+      setLabel(formatRelativeTime(timestamp));
+    }, 30_000);
+    return () => clearInterval(timer);
+  }, [timestamp]);
+
+  // suppressHydrationWarning is belt-and-braces — the fallback already
+  // matches between server and initial client render, but a consumer that
+  // passes a non-empty fallback could still get a momentary mismatch.
+  return (
+    <span className={className} suppressHydrationWarning>
+      {mounted ? label : fallback}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary

Found two chat-page production bugs during an end-to-end test of the live Vercel deploy:

- **React hydration error #418** is thrown 1-3x on the `/chat` page. `formatRelativeTime(ts)` calls `formatDistanceToNow(new Date(), …)` during render, so the SSR output and the client output drift by a few ms and React aborts hydration. Fix: new client-only `<RelativeTime>` component that renders a stable placeholder on the server and hydrates the real label on mount (also ticks every 30s so "less than a minute ago" rolls over). Applied to both timestamp call sites in chat layout + `ChatMessage`.

- **Send button strands users on an optimistic "Thinking…" state when the gateway is unreachable.** The Vercel deploy has no `NEXT_PUBLIC_WS_URL`, so the client tries `ws://localhost:4000/ws` from an HTTPS origin, which the browser blocks. `handleSend` still flipped the UI to "thinking" with no response coming. Fix: block send when `wsState !== "connected"`, and show a yellow "Gateway not connected" banner (mirrors the Dashboard's Demo Mode banner) with a pointer to `pnpm gateway:dev` or `NEXT_PUBLIC_WS_URL`.

## Test plan

- [x] Local dev (`pnpm gateway:dev` + `pnpm --filter @karna/web dev`): chat still works end-to-end, real assistant reply arrives, no hydration warnings in console.
- [x] `pnpm --filter @karna/web typecheck` passes.
- [ ] On Vercel (no gateway): banner shows, Send button disabled, no "Thinking…" limbo.

Note: branched off `d4b7488` because `main` has unrelated WIP ahead of it; happy to rebase onto `a65f414` if you want — my changes are additive on top of the existing chat page and shouldn't semantically conflict.