### PR TITLE
fix(config): align gateway CORS schema with shared config format

### DIFF
--- a/gateway/src/config/runtime-env.ts
+++ b/gateway/src/config/runtime-env.ts
@@ -32,8 +32,8 @@ export function resolveGatewayCorsOrigins(config: KarnaConfig): string[] {
     return envOrigins;
   }
 
-  if (config.gateway.corsOrigin) {
-    return [config.gateway.corsOrigin];
+  if (config.gateway.cors.origins.length > 0) {
+    return config.gateway.cors.origins;
   }
 
   return ["http://localhost:3000", "http://localhost:5173"];

--- a/gateway/src/config/schema.ts
+++ b/gateway/src/config/schema.ts
@@ -9,7 +9,11 @@ export const GatewayConfigSchema = z.object({
   maxConnections: z.number().int().positive().default(100),
   heartbeatIntervalMs: z.number().int().positive().default(30_000),
   sessionTimeoutMs: z.number().int().positive().default(3_600_000),
-  corsOrigin: z.string().default(""),
+  cors: z
+    .object({
+      origins: z.array(z.string()).default([]),
+    })
+    .default({}),
 });
 
 export type GatewayConfig = z.infer<typeof GatewayConfigSchema>;

--- a/tests/gateway/config-schema.test.ts
+++ b/tests/gateway/config-schema.test.ts
@@ -16,7 +16,7 @@ describe("Config Schema", () => {
       expect(config.maxConnections).toBe(100);
       expect(config.heartbeatIntervalMs).toBe(30_000);
       expect(config.sessionTimeoutMs).toBe(3_600_000);
-      expect(config.corsOrigin).toBe("");
+      expect(config.cors.origins).toEqual([]);
     });
 
     it("validates port is positive integer", () => {

--- a/tests/gateway/runtime-routes.test.ts
+++ b/tests/gateway/runtime-routes.test.ts
@@ -37,7 +37,7 @@ describe("runtime routes", () => {
         maxConnections: 25,
         heartbeatIntervalMs: 20_000,
         sessionTimeoutMs: 8_000,
-        corsOrigin: "https://karna.example.com",
+        cors: { origins: ["https://karna.example.com"] },
       },
       agent: {
         defaultModel: "claude-sonnet-4-20250514",

--- a/tests/shared/config-validation.test.ts
+++ b/tests/shared/config-validation.test.ts
@@ -6,9 +6,9 @@ import {
 } from "../../gateway/src/config/schema.js";
 
 describe("Configuration Validation - Security", () => {
-  it("CORS defaults to empty string (must be configured explicitly)", () => {
+  it("CORS defaults to empty origins array (must be configured explicitly)", () => {
     const config = GatewayConfigSchema.parse({});
-    expect(config.corsOrigin).toBe("");
+    expect(config.cors.origins).toEqual([]);
   });
 
   it("authToken is optional (dev-only concern)", () => {
@@ -46,7 +46,7 @@ describe("Configuration Validation - Security", () => {
         maxConnections: 500,
         heartbeatIntervalMs: 15_000,
         sessionTimeoutMs: 1_800_000,
-        corsOrigin: "https://myapp.com",
+        cors: { origins: ["https://myapp.com"] },
       },
       agent: {
         defaultModel: "claude-opus-4-20250514",


### PR DESCRIPTION
## Problem

`karna onboard` (CLI wizard) writes the gateway CORS configuration in the format used by `@karna/shared`:

```json
{
  "gateway": {
    "cors": { "origins": ["*"], "credentials": true }
  }
}
```

But the gateway's own `KarnaConfigSchema` (in `gateway/src/config/schema.ts`) expected a flat string field `corsOrigin`. When Zod parsed the wizard-generated config file, it stripped the unrecognised `cors` object and fell back to the empty-string default — so **any CORS config set during onboarding was silently ignored**.

The practical effect: users who ran `karna onboard` and then started the gateway would get the hardcoded localhost fallback origins (`http://localhost:3000`, `http://localhost:5173`) regardless of what they configured.

## Fix

Replace `corsOrigin: z.string()` with `cors: z.object({ origins: z.array(z.string()) })` in the gateway schema, matching the shape that the shared config and the CLI wizard already produce.

Update `resolveGatewayCorsOrigins()` to read from `config.gateway.cors.origins`.

The `/api/runtime` response continues to expose CORS origins as a comma-joined string (`corsOrigin`) for backwards compatibility with any existing clients reading that field.

## Files changed

- `gateway/src/config/schema.ts` — new `cors.origins` array field
- `gateway/src/config/runtime-env.ts` — read from `cors.origins`
- `tests/gateway/config-schema.test.ts` — updated assertions
- `tests/gateway/runtime-routes.test.ts` — updated config fixture
- `tests/shared/config-validation.test.ts` — updated assertions

All 1007 tests pass after this change.