### PR TITLE
docs: note karna-ai npm package is not yet published

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Today, Karna ships as a **self-hosted, production-ready assistant stack** with w
 
 ### Install (Fastest Path Today)
 
+> **Heads up:** the `karna-ai` npm package is not yet published. Use the [From source](#other-install-methods) or Docker path below. The command here describes the intended UX once `karna-ai` ships.
+
 ```bash
 npm install -g karna-ai
 ```


### PR DESCRIPTION
## Summary
- README's "Fastest Path Today" section tells users to `npm install -g karna-ai`, but the package returns 404 on npm
- Adds a heads-up pointing readers to the source / Docker install paths in the meantime

## Test plan
- [x] `npm view karna-ai` → 404 (confirms package not yet published)
- [x] Source and Docker install paths still work from this README