### PR TITLE
feat: trends-2026 wave 5 — web & mobile UI (dashboards, approvals, marketplace)

### DIFF
--- a/apps/mobile/app/(tabs)/settings/index.tsx
+++ b/apps/mobile/app/(tabs)/settings/index.tsx
@@ -25,6 +25,10 @@ export default function SettingsScreen() {
   const setDarkMode = useAppStore((s) => s.setDarkMode);
   const notifications = useAppStore((s) => s.notifications);
   const setNotifications = useAppStore((s) => s.setNotifications);
+  const notifyApprovals = useAppStore((s) => s.notifyApprovals);
+  const setNotifyApprovals = useAppStore((s) => s.setNotifyApprovals);
+  const notifyRunCompletion = useAppStore((s) => s.notifyRunCompletion);
+  const setNotifyRunCompletion = useAppStore((s) => s.setNotifyRunCompletion);
   const hapticsEnabled = useAppStore((s) => s.hapticsEnabled);
   const setHapticsEnabled = useAppStore((s) => s.setHapticsEnabled);
   const agentName = useAppStore((s) => s.agentName);
@@ -428,6 +432,76 @@ export default function SettingsScreen() {
               }}
               thumbColor={
                 notifications ? colors.primary : colors.textTertiary
+              }
+            />
+          </View>
+
+          <View style={[styles.divider, { backgroundColor: colors.border }]} />
+
+          <View style={styles.row}>
+            <View style={styles.rowLabel}>
+              <Feather name="shield" size={18} color={colors.textSecondary} />
+              <View>
+                <Text style={[styles.label, { color: colors.text }]}>
+                  Approval Requests
+                </Text>
+                <Text style={[styles.helpText, { color: colors.textSecondary }]}>
+                  Alert me when Karna needs approval to run a tool.
+                </Text>
+              </View>
+            </View>
+            <Switch
+              value={notifyApprovals}
+              disabled={!notifications}
+              onValueChange={(val) => {
+                setNotifyApprovals(val);
+                void playHaptic('selection');
+              }}
+              trackColor={{
+                false: colors.surfaceAlt,
+                true: colors.primary + '60',
+              }}
+              thumbColor={
+                notifyApprovals && notifications
+                  ? colors.primary
+                  : colors.textTertiary
+              }
+            />
+          </View>
+
+          <View style={[styles.divider, { backgroundColor: colors.border }]} />
+
+          <View style={styles.row}>
+            <View style={styles.rowLabel}>
+              <Feather
+                name="check-circle"
+                size={18}
+                color={colors.textSecondary}
+              />
+              <View>
+                <Text style={[styles.label, { color: colors.text }]}>
+                  Task Completion
+                </Text>
+                <Text style={[styles.helpText, { color: colors.textSecondary }]}>
+                  Alert me when a long-running task finishes.
+                </Text>
+              </View>
+            </View>
+            <Switch
+              value={notifyRunCompletion}
+              disabled={!notifications}
+              onValueChange={(val) => {
+                setNotifyRunCompletion(val);
+                void playHaptic('selection');
+              }}
+              trackColor={{
+                false: colors.surfaceAlt,
+                true: colors.primary + '60',
+              }}
+              thumbColor={
+                notifyRunCompletion && notifications
+                  ? colors.primary
+                  : colors.textTertiary
               }
             />
           </View>

--- a/apps/mobile/app/(tabs)/tasks/index.tsx
+++ b/apps/mobile/app/(tabs)/tasks/index.tsx
@@ -16,6 +16,7 @@ import { playHaptic } from '@/lib/haptics';
 import { gatewayClient } from '@/lib/gateway-client';
 import { getColors, Typography, Spacing, BorderRadius } from '@/lib/theme';
 import { TaskCard } from '@/components/TaskCard';
+import { PendingApprovals } from '@/components/PendingApprovals';
 
 export default function TasksScreen() {
   const darkMode = useAppStore((s) => s.darkMode);
@@ -124,13 +125,19 @@ export default function TasksScreen() {
             />
           }
           ListHeaderComponent={
-            pendingReminders.length > 0 ? (
-              <Text
-                style={[styles.sectionHeader, { color: colors.textSecondary }]}
-              >
-                Active ({pendingReminders.length})
-              </Text>
-            ) : null
+            <>
+              <PendingApprovals />
+              {pendingReminders.length > 0 ? (
+                <Text
+                  style={[
+                    styles.sectionHeader,
+                    { color: colors.textSecondary },
+                  ]}
+                >
+                  Active ({pendingReminders.length})
+                </Text>
+              ) : null}
+            </>
           }
           ListEmptyComponent={
             <View style={styles.emptyContainer}>

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -14,6 +14,7 @@ import { gatewayClient } from '@/lib/gateway-client';
 import {
   addNotificationReceivedListener,
   addNotificationResponseListener,
+  parseKarnaNotificationData,
 } from '@/lib/notifications';
 import ErrorBoundary from '@/components/ErrorBoundary';
 
@@ -211,10 +212,15 @@ function RootLayoutInner() {
 
     responseListenerRef.current = addNotificationResponseListener(
       (response) => {
-        const data = response.notification.request.content.data as
+        const rawData = response.notification.request.content.data as
           | { tab?: string }
           | undefined;
-        const route = getMobileTabRoute(data?.tab);
+
+        // Prefer the typed Karna payload (approval-needed / run-complete) so
+        // those notifications deep-link to the right surface; fall back to the
+        // generic `tab` field for any other notification.
+        const karnaData = parseKarnaNotificationData(rawData);
+        const route = getMobileTabRoute(karnaData?.tab ?? rawData?.tab);
         if (route) {
           router.push(route as never);
         }

--- a/apps/mobile/components/PendingApprovals.tsx
+++ b/apps/mobile/components/PendingApprovals.tsx
@@ -1,0 +1,172 @@
+import React from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { gatewayClient } from '@/lib/gateway-client';
+import { useAppStore, type ToolApprovalRequest } from '@/lib/store';
+import { BorderRadius, Spacing, Typography, getColors } from '@/lib/theme';
+
+/**
+ * Human approval checkpoints surface (issue #586).
+ *
+ * Lists tool calls awaiting human approval and lets the user act on them inline.
+ * The store currently tracks a single in-flight approval (`pendingToolApproval`),
+ * so this renders that one when present. The full-screen {@link ToolApprovalModal}
+ * (rendered globally in the tabs layout) handles the detailed review; this card
+ * gives the approval a persistent, discoverable home inside the Tasks tab and an
+ * inline approve/deny shortcut.
+ */
+export function PendingApprovals() {
+  const darkMode = useAppStore((s) => s.darkMode);
+  const request = useAppStore((s) => s.pendingToolApproval);
+  const colors = getColors(darkMode ? 'dark' : 'light');
+
+  if (!request) return null;
+
+  const riskColor = getRiskColor(request.riskLevel, colors);
+
+  return (
+    <View style={styles.container}>
+      <Text style={[styles.sectionHeader, { color: colors.textSecondary }]}>
+        Pending Approvals (1)
+      </Text>
+      <View
+        style={[
+          styles.card,
+          { backgroundColor: colors.card, borderColor: riskColor },
+        ]}
+      >
+        <View style={styles.header}>
+          <View style={[styles.iconFrame, { backgroundColor: riskColor + '20' }]}>
+            <Feather name="shield" size={18} color={riskColor} />
+          </View>
+          <View style={styles.headerText}>
+            <Text style={[styles.title, { color: colors.text }]} numberOfLines={1}>
+              {request.toolName}
+            </Text>
+            <Text style={[styles.subtitle, { color: riskColor }]}>
+              {request.riskLevel.toUpperCase()} RISK
+            </Text>
+          </View>
+        </View>
+
+        {request.description ? (
+          <Text
+            style={[styles.description, { color: colors.textSecondary }]}
+            numberOfLines={2}
+          >
+            {request.description}
+          </Text>
+        ) : null}
+
+        <View style={styles.actions}>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Deny pending tool request"
+            onPress={() => deny(request)}
+            style={[styles.button, { borderColor: colors.border }]}
+          >
+            <Text style={[styles.buttonText, { color: colors.text }]}>Deny</Text>
+          </Pressable>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Approve pending tool request"
+            onPress={() => approve(request)}
+            style={[styles.primaryButton, { backgroundColor: colors.primary }]}
+          >
+            <Text style={styles.primaryButtonText}>Approve</Text>
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+function approve(request: ToolApprovalRequest): void {
+  gatewayClient.respondToToolApproval(request.toolCallId, true);
+}
+
+function deny(request: ToolApprovalRequest): void {
+  gatewayClient.respondToToolApproval(request.toolCallId, false);
+}
+
+function getRiskColor(
+  riskLevel: ToolApprovalRequest['riskLevel'],
+  colors: ReturnType<typeof getColors>,
+): string {
+  if (riskLevel === 'critical') return colors.error;
+  if (riskLevel === 'high') return colors.warning;
+  if (riskLevel === 'medium') return colors.primary;
+  return colors.success;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: Spacing.lg,
+    paddingTop: Spacing.lg,
+  },
+  sectionHeader: {
+    ...Typography.captionBold,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginBottom: Spacing.sm,
+  },
+  card: {
+    borderWidth: 1,
+    borderRadius: BorderRadius.lg,
+    padding: Spacing.md,
+    gap: Spacing.sm,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.md,
+  },
+  iconFrame: {
+    width: 36,
+    height: 36,
+    borderRadius: BorderRadius.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  headerText: {
+    flex: 1,
+  },
+  title: {
+    ...Typography.bodyBold,
+  },
+  subtitle: {
+    ...Typography.small,
+    fontWeight: '600',
+    marginTop: Spacing.xxs,
+  },
+  description: {
+    ...Typography.caption,
+  },
+  actions: {
+    flexDirection: 'row',
+    gap: Spacing.sm,
+    marginTop: Spacing.xs,
+  },
+  button: {
+    flex: 1,
+    minHeight: 40,
+    borderWidth: 1,
+    borderRadius: BorderRadius.sm,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  primaryButton: {
+    flex: 1,
+    minHeight: 40,
+    borderRadius: BorderRadius.sm,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  buttonText: {
+    ...Typography.captionBold,
+  },
+  primaryButtonText: {
+    ...Typography.captionBold,
+    color: '#FFFFFF',
+  },
+});

--- a/apps/mobile/lib/gateway-client.ts
+++ b/apps/mobile/lib/gateway-client.ts
@@ -13,6 +13,11 @@ import {
   deriveMobileGatewayHealthUrl,
   normalizeMobileGatewayWsUrl,
 } from "./runtime-config";
+import {
+  notifyApprovalNeeded,
+  notifyRunComplete,
+  type KarnaNotificationPreferences,
+} from "./notifications";
 
 // ── Protocol Types ───────────────────────────────────────────────────────────
 
@@ -660,6 +665,12 @@ class GatewayClient {
 
         this.clearApprovalTimeout(toolCallId);
         store.setPendingToolApproval(request);
+        void notifyApprovalNeeded(
+          { toolName, toolCallId, riskLevel },
+          readNotificationPreferences(),
+        ).catch((err) =>
+          console.warn("[GatewayClient] Approval notification failed:", err),
+        );
         this.approvalTimeouts.set(
           toolCallId,
           setTimeout(() => {
@@ -754,12 +765,46 @@ class GatewayClient {
       }
 
       case "orchestration.status": {
+        const state = payload.state as string | undefined;
+        if (state === "completed" || state === "failed") {
+          this.handleRunComplete(payload, state === "failed");
+        }
+        break;
+      }
+
+      case "orchestration.complete":
+      case "run.complete": {
+        this.handleRunComplete(payload, Boolean(payload.isError));
         break;
       }
 
       default:
         break;
     }
+  }
+
+  private handleRunComplete(
+    payload: Record<string, unknown>,
+    failed: boolean,
+  ): void {
+    const title =
+      (typeof payload.title === "string" && payload.title) ||
+      (typeof payload.name === "string" && payload.name) ||
+      (typeof payload.goal === "string" && payload.goal) ||
+      "Background task";
+    const runId =
+      (typeof payload.runId === "string" && payload.runId) ||
+      (typeof payload.orchestrationId === "string" &&
+        payload.orchestrationId) ||
+      (typeof payload.id === "string" && payload.id) ||
+      undefined;
+
+    void notifyRunComplete(
+      { title, runId, success: !failed },
+      readNotificationPreferences(),
+    ).catch((err) =>
+      console.warn("[GatewayClient] Run-complete notification failed:", err),
+    );
   }
 
   private addSystemMessage(content: string): void {
@@ -876,6 +921,15 @@ class GatewayClient {
 
 function generateId(): string {
   return `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+function readNotificationPreferences(): KarnaNotificationPreferences {
+  const state = useAppStore.getState();
+  return {
+    enabled: state.notifications,
+    approvalsEnabled: state.notifyApprovals,
+    runCompletionEnabled: state.notifyRunCompletion,
+  };
 }
 
 function isChatRole(role: unknown): role is ChatMessage["role"] {

--- a/apps/mobile/lib/notifications.ts
+++ b/apps/mobile/lib/notifications.ts
@@ -1,5 +1,6 @@
 import * as Notifications from 'expo-notifications';
 import { Platform } from 'react-native';
+import type { MobileTab } from './deep-links';
 
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
@@ -89,4 +90,165 @@ export function addNotificationResponseListener(
   handler: (response: Notifications.NotificationResponse) => void,
 ): Notifications.Subscription {
   return Notifications.addNotificationResponseReceivedListener(handler);
+}
+
+// ── Karna notification dispatch (issue #612) ─────────────────────────────────
+//
+// All Expo-notifications side effects are routed through the small `NotificationBackend`
+// interface below so the routing / scheduling logic can be unit-tested in a plain
+// Node (vitest) environment without the native module. The default backend simply
+// forwards to the real `expo-notifications` helpers defined above.
+
+/** Categories of Karna notifications. Each maps to a deep-link target tab. */
+export type KarnaNotificationKind = 'approval-needed' | 'run-complete';
+
+/** Notification content + the deep-link data the response handler will route on. */
+export interface KarnaNotificationData {
+  /** Discriminator so the response handler can branch on notification kind. */
+  kind: KarnaNotificationKind;
+  /** Deep-link target tab consumed by `getMobileTabRoute` in the response handler. */
+  tab: MobileTab;
+  /** Tool call awaiting approval (approval-needed only). */
+  toolCallId?: string;
+  /** Originating run / orchestration id (run-complete only). */
+  runId?: string;
+}
+
+/** User opt-in preferences for the two notification kinds. */
+export interface KarnaNotificationPreferences {
+  /** Master switch (mirrors the existing `notifications` store flag). */
+  enabled: boolean;
+  /** Notify when a tool/checkpoint needs human approval. */
+  approvalsEnabled: boolean;
+  /** Notify when a long-running task finishes. */
+  runCompletionEnabled: boolean;
+}
+
+/**
+ * Minimal surface of `expo-notifications` that the dispatch logic depends on.
+ * Injecting this keeps the core routable/schedulable logic free of the native
+ * module so it can run under vitest.
+ */
+export interface NotificationBackend {
+  scheduleImmediate(
+    title: string,
+    body: string,
+    data: KarnaNotificationData,
+  ): Promise<string>;
+  cancel(notificationId: string): Promise<void>;
+}
+
+const defaultBackend: NotificationBackend = {
+  async scheduleImmediate(title, body, data) {
+    return Notifications.scheduleNotificationAsync({
+      content: { title, body, sound: true, data: { ...data } },
+      trigger: null,
+    });
+  },
+  async cancel(notificationId) {
+    await Notifications.cancelScheduledNotificationAsync(notificationId);
+  },
+};
+
+let activeBackend: NotificationBackend = defaultBackend;
+
+/** Override the notification backend (used by tests). Pass nothing to reset. */
+export function setNotificationBackend(backend?: NotificationBackend): void {
+  activeBackend = backend ?? defaultBackend;
+}
+
+/** Map a notification kind to its deep-link tab. */
+export function notificationTabForKind(kind: KarnaNotificationKind): MobileTab {
+  return kind === 'approval-needed' ? 'tasks' : 'tasks';
+}
+
+/**
+ * Decide whether a notification of the given kind should be dispatched, given
+ * the user's preferences. Exposed for testing and to keep the policy in one place.
+ */
+export function shouldNotify(
+  kind: KarnaNotificationKind,
+  preferences: KarnaNotificationPreferences,
+): boolean {
+  if (!preferences.enabled) return false;
+  if (kind === 'approval-needed') return preferences.approvalsEnabled;
+  return preferences.runCompletionEnabled;
+}
+
+/**
+ * Dispatch an "approval needed" notification, deep-linking to the approvals
+ * surface in the Tasks tab. Returns the scheduled notification id, or null when
+ * preferences suppress it.
+ */
+export async function notifyApprovalNeeded(
+  input: { toolName: string; toolCallId: string; riskLevel?: string },
+  preferences: KarnaNotificationPreferences,
+): Promise<string | null> {
+  if (!shouldNotify('approval-needed', preferences)) return null;
+
+  const risk = input.riskLevel ? ` (${input.riskLevel} risk)` : '';
+  return activeBackend.scheduleImmediate(
+    'Approval needed',
+    `Karna wants to run "${input.toolName}"${risk}. Tap to review.`,
+    {
+      kind: 'approval-needed',
+      tab: notificationTabForKind('approval-needed'),
+      toolCallId: input.toolCallId,
+    },
+  );
+}
+
+/**
+ * Dispatch a "run complete" notification for a finished long-running task,
+ * deep-linking to the Tasks tab. Returns the scheduled notification id, or null
+ * when preferences suppress it.
+ */
+export async function notifyRunComplete(
+  input: { title: string; runId?: string; success?: boolean },
+  preferences: KarnaNotificationPreferences,
+): Promise<string | null> {
+  if (!shouldNotify('run-complete', preferences)) return null;
+
+  const outcome = input.success === false ? 'finished with errors' : 'completed';
+  return activeBackend.scheduleImmediate(
+    'Task complete',
+    `"${input.title}" ${outcome}. Tap to view.`,
+    {
+      kind: 'run-complete',
+      tab: notificationTabForKind('run-complete'),
+      runId: input.runId,
+    },
+  );
+}
+
+/** Cancel a previously dispatched notification by id. */
+export async function cancelKarnaNotification(id: string): Promise<void> {
+  await activeBackend.cancel(id);
+}
+
+/**
+ * Parse the `data` payload off a notification response into a typed Karna
+ * notification, or return null when it is not a Karna notification. Pure and
+ * unit-testable; the layout's response listener uses this to route deep links.
+ */
+export function parseKarnaNotificationData(
+  data: unknown,
+): KarnaNotificationData | null {
+  if (typeof data !== 'object' || data === null) return null;
+  const record = data as Record<string, unknown>;
+  const kind = record.kind;
+  if (kind !== 'approval-needed' && kind !== 'run-complete') return null;
+
+  const tab =
+    typeof record.tab === 'string'
+      ? (record.tab as MobileTab)
+      : notificationTabForKind(kind);
+
+  return {
+    kind,
+    tab,
+    toolCallId:
+      typeof record.toolCallId === 'string' ? record.toolCallId : undefined,
+    runId: typeof record.runId === 'string' ? record.runId : undefined,
+  };
 }

--- a/apps/mobile/lib/store.ts
+++ b/apps/mobile/lib/store.ts
@@ -17,6 +17,8 @@ const STORE_FILE = `${FileSystem.documentDirectory}karna-store.json`;
 interface PersistedState {
   darkMode: boolean;
   notifications: boolean;
+  notifyApprovals: boolean;
+  notifyRunCompletion: boolean;
   hapticsEnabled: boolean;
   agentName: string;
   url: string;
@@ -34,6 +36,8 @@ interface PersistedState {
 const PERSIST_KEYS: (keyof PersistedState)[] = [
   "darkMode",
   "notifications",
+  "notifyApprovals",
+  "notifyRunCompletion",
   "hapticsEnabled",
   "agentName",
   "url",
@@ -233,6 +237,8 @@ interface SkillSlice {
 interface SettingsSlice {
   darkMode: boolean;
   notifications: boolean;
+  notifyApprovals: boolean;
+  notifyRunCompletion: boolean;
   hapticsEnabled: boolean;
   agentName: string;
   liveVoiceEnabled: boolean;
@@ -240,6 +246,8 @@ interface SettingsSlice {
   authCallbackCode: string;
   setDarkMode: (enabled: boolean) => void;
   setNotifications: (enabled: boolean) => void;
+  setNotifyApprovals: (enabled: boolean) => void;
+  setNotifyRunCompletion: (enabled: boolean) => void;
   setHapticsEnabled: (enabled: boolean) => void;
   setAgentName: (name: string) => void;
   setLiveVoiceEnabled: (enabled: boolean) => void;
@@ -390,6 +398,8 @@ export const useAppStore = create<AppState>()((set) => ({
   // Settings
   darkMode: true,
   notifications: true,
+  notifyApprovals: true,
+  notifyRunCompletion: true,
   hapticsEnabled: true,
   agentName: "Karna",
   liveVoiceEnabled: false,
@@ -397,6 +407,8 @@ export const useAppStore = create<AppState>()((set) => ({
   authCallbackCode: "",
   setDarkMode: (darkMode) => set({ darkMode }),
   setNotifications: (notifications) => set({ notifications }),
+  setNotifyApprovals: (notifyApprovals) => set({ notifyApprovals }),
+  setNotifyRunCompletion: (notifyRunCompletion) => set({ notifyRunCompletion }),
   setHapticsEnabled: (hapticsEnabled) => set({ hapticsEnabled }),
   setAgentName: (agentName) => set({ agentName }),
   setLiveVoiceEnabled: (liveVoiceEnabled) => set({ liveVoiceEnabled }),

--- a/apps/web/app/api/approvals/[id]/route.ts
+++ b/apps/web/app/api/approvals/[id]/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest } from "next/server";
+import { proxyGateway, proxyGatewayGet } from "../../_gateway";
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id } = await context.params;
+  return proxyGatewayGet(request, `/api/approvals/${id}`);
+}
+
+// POST a decision for a single approval: { decision: 'approve' | 'deny', args?: unknown }
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id } = await context.params;
+  return proxyGateway(request, `/api/approvals/${id}`, { method: "POST" });
+}

--- a/apps/web/app/api/approvals/route.ts
+++ b/apps/web/app/api/approvals/route.ts
@@ -1,0 +1,10 @@
+import { NextRequest } from "next/server";
+import { proxyGateway, proxyGatewayGet } from "../_gateway";
+
+export async function GET(request: NextRequest) {
+  return proxyGatewayGet(request, "/api/approvals");
+}
+
+export async function POST(request: NextRequest) {
+  return proxyGateway(request, "/api/approvals", { method: "POST" });
+}

--- a/apps/web/app/api/marketplace/[id]/install/route.ts
+++ b/apps/web/app/api/marketplace/[id]/install/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest } from "next/server";
+import { proxyGateway } from "../../../_gateway";
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id } = await context.params;
+  return proxyGateway(request, `/api/marketplace/${id}/install`, {
+    method: "POST",
+  });
+}

--- a/apps/web/app/api/marketplace/[id]/route.ts
+++ b/apps/web/app/api/marketplace/[id]/route.ts
@@ -1,0 +1,10 @@
+import { NextRequest } from "next/server";
+import { proxyGatewayGet } from "../../_gateway";
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id } = await context.params;
+  return proxyGatewayGet(request, `/api/marketplace/${id}`);
+}

--- a/apps/web/app/api/marketplace/route.ts
+++ b/apps/web/app/api/marketplace/route.ts
@@ -1,0 +1,6 @@
+import { NextRequest } from "next/server";
+import { proxyGatewayGet } from "../_gateway";
+
+export async function GET(request: NextRequest) {
+  return proxyGatewayGet(request, "/api/marketplace");
+}

--- a/apps/web/app/api/sessions/[id]/traces/route.ts
+++ b/apps/web/app/api/sessions/[id]/traces/route.ts
@@ -1,0 +1,10 @@
+import { NextRequest } from "next/server";
+import { proxyGatewayGet } from "../../../_gateway";
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  const { id } = await context.params;
+  return proxyGatewayGet(request, `/api/sessions/${id}/traces`);
+}

--- a/apps/web/app/dashboard/approvals/page.tsx
+++ b/apps/web/app/dashboard/approvals/page.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ShieldAlert } from "lucide-react";
+import { Badge } from "@/components/Badge";
+import { Modal } from "@/components/Modal";
+import {
+  formatArgs,
+  normalizeApprovals,
+  parseEditedArgs,
+  riskBadgeVariant,
+  type PendingApproval,
+} from "@/components/approvals";
+
+const POLL_MS = 4000;
+
+export default function ApprovalsPage() {
+  const [approvals, setApprovals] = useState<PendingApproval[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [editing, setEditing] = useState<PendingApproval | null>(null);
+  const [editText, setEditText] = useState("");
+  const [editError, setEditError] = useState<string | null>(null);
+  const firstLoad = useRef(true);
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await fetch("/api/approvals", { cache: "no-store" });
+      if (!res.ok) throw new Error(`Failed with ${res.status}`);
+      const data = await res.json();
+      setApprovals(normalizeApprovals(data).filter((a) => a.status === "pending"));
+      setError(null);
+    } catch (e) {
+      // Keep last-known list on transient poll errors; only surface on first load.
+      if (firstLoad.current) {
+        setError(e instanceof Error ? e.message : "Failed to load approvals");
+      }
+    } finally {
+      if (firstLoad.current) {
+        firstLoad.current = false;
+        setIsLoading(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+    const timer = setInterval(refresh, POLL_MS);
+    return () => clearInterval(timer);
+  }, [refresh]);
+
+  async function decide(
+    approval: PendingApproval,
+    decision: "approve" | "deny",
+    args?: Record<string, unknown>,
+  ) {
+    setBusyId(approval.id);
+    try {
+      const res = await fetch(`/api/approvals/${approval.id}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ decision, ...(args ? { args } : {}) }),
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(data.error ?? `Decision failed with ${res.status}`);
+      }
+      setApprovals((prev) => prev.filter((x) => x.id !== approval.id));
+      setEditing(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Decision failed");
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  function openEdit(approval: PendingApproval) {
+    setEditing(approval);
+    setEditText(formatArgs(approval.args));
+    setEditError(null);
+  }
+
+  function submitEdit() {
+    if (!editing) return;
+    const parsed = parseEditedArgs(editText);
+    if (!parsed.ok) {
+      setEditError(parsed.error);
+      return;
+    }
+    decide(editing, "approve", parsed.value);
+  }
+
+  return (
+    <div className="p-4 sm:p-6 space-y-4 sm:space-y-6 overflow-y-auto h-full">
+      {error && (
+        <div className="rounded-lg border border-danger-500/30 bg-danger-500/10 px-4 py-3 text-sm text-danger-400">
+          {error}
+        </div>
+      )}
+
+      <div className="flex items-center gap-3">
+        <div>
+          <h1 className="text-xl font-semibold text-white">Approvals</h1>
+          <p className="text-sm text-dark-400 mt-1">
+            High-risk tool calls awaiting your decision. Updates automatically.
+          </p>
+        </div>
+        {approvals.length > 0 && (
+          <Badge variant="warning">{approvals.length} pending</Badge>
+        )}
+      </div>
+
+      {isLoading ? (
+        <div className="rounded-xl border border-dark-700 bg-dark-800 px-5 py-12 text-center text-sm text-dark-400">
+          Loading pending approvals...
+        </div>
+      ) : approvals.length === 0 ? (
+        <div className="rounded-xl border border-dark-700 bg-dark-800 px-5 py-12 text-center text-sm text-dark-400">
+          <ShieldAlert size={28} className="mx-auto mb-3 text-success-400" />
+          No pending approvals. You&apos;re all caught up.
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {approvals.map((approval) => (
+            <div
+              key={approval.id}
+              className="rounded-xl border border-dark-700 bg-dark-800 p-5 space-y-3"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div className="flex items-center gap-2">
+                  <code className="text-sm font-medium text-dark-100">
+                    {approval.toolName}
+                  </code>
+                  <Badge variant={riskBadgeVariant(approval.riskLevel)}>
+                    {approval.riskLevel}
+                  </Badge>
+                </div>
+                <div className="flex items-center gap-3 text-xs text-dark-500">
+                  {approval.sessionId && (
+                    <span className="font-mono">
+                      session {approval.sessionId.slice(0, 8)}
+                    </span>
+                  )}
+                  {approval.requestedAt && (
+                    <span>{new Date(approval.requestedAt).toLocaleString()}</span>
+                  )}
+                </div>
+              </div>
+
+              {approval.reason && (
+                <p className="text-sm text-dark-400">{approval.reason}</p>
+              )}
+
+              <pre className="max-h-60 overflow-auto rounded-lg bg-dark-900/70 p-3 text-xs text-dark-300">
+                {formatArgs(approval.args)}
+              </pre>
+
+              <div className="flex flex-wrap gap-2">
+                <button
+                  onClick={() => decide(approval, "approve")}
+                  disabled={busyId === approval.id}
+                  className="rounded-lg bg-success-500/20 px-4 py-2 text-sm font-medium text-success-400 hover:bg-success-500/30 disabled:opacity-50 transition-colors"
+                >
+                  Approve
+                </button>
+                <button
+                  onClick={() => decide(approval, "deny")}
+                  disabled={busyId === approval.id}
+                  className="rounded-lg bg-danger-500/20 px-4 py-2 text-sm font-medium text-danger-400 hover:bg-danger-500/30 disabled:opacity-50 transition-colors"
+                >
+                  Deny
+                </button>
+                <button
+                  onClick={() => openEdit(approval)}
+                  disabled={busyId === approval.id}
+                  className="rounded-lg bg-dark-700 px-4 py-2 text-sm text-white hover:bg-dark-600 disabled:opacity-50 transition-colors"
+                >
+                  Edit args
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <Modal
+        open={!!editing}
+        onClose={() => setEditing(null)}
+        title={editing ? `Edit args — ${editing.toolName}` : undefined}
+        size="lg"
+      >
+        <p className="mb-2 text-sm text-dark-400">
+          Edit the arguments below, then approve with the modified call.
+        </p>
+        <textarea
+          value={editText}
+          onChange={(e) => setEditText(e.target.value)}
+          spellCheck={false}
+          rows={12}
+          className="w-full rounded-lg border border-dark-700 bg-dark-900/70 p-3 font-mono text-xs text-dark-200 focus:outline-none focus:border-accent-500"
+        />
+        {editError && <div className="mt-2 text-sm text-danger-400">{editError}</div>}
+        <div className="mt-4 flex justify-end gap-2">
+          <button
+            onClick={() => setEditing(null)}
+            className="rounded-lg bg-dark-700 px-4 py-2 text-sm text-white hover:bg-dark-600 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={submitEdit}
+            disabled={!!busyId}
+            className="rounded-lg bg-success-500/20 px-4 py-2 text-sm font-medium text-success-400 hover:bg-success-500/30 disabled:opacity-50 transition-colors"
+          >
+            Approve with edits
+          </button>
+        </div>
+      </Modal>
+    </div>
+  );
+}

--- a/apps/web/app/dashboard/debugger/page.tsx
+++ b/apps/web/app/dashboard/debugger/page.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { RunDebugger } from "@/components/RunDebugger";
+import { normalizeSteps, type RunStep } from "@/components/runTrace";
+
+interface SessionSummary {
+  id: string;
+  sessionId?: string;
+  title?: string;
+  channelType?: string;
+  createdAt?: string | number;
+  startedAt?: string | number;
+}
+
+function sessionLabel(session: SessionSummary): string {
+  const id = session.id ?? session.sessionId ?? "";
+  const created = session.createdAt ?? session.startedAt;
+  const when = created ? ` — ${new Date(created).toLocaleString()}` : "";
+  return `${session.title ?? session.channelType ?? id}${when}`;
+}
+
+export default function DebuggerPage() {
+  const [sessions, setSessions] = useState<SessionSummary[]>([]);
+  const [selectedId, setSelectedId] = useState<string>("");
+  const [steps, setSteps] = useState<RunStep[]>([]);
+  const [loadingSessions, setLoadingSessions] = useState(true);
+  const [loadingRun, setLoadingRun] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/sessions", { cache: "no-store" })
+      .then((r) => r.json())
+      .then((data) => {
+        if (cancelled) return;
+        const list: SessionSummary[] = Array.isArray(data)
+          ? data
+          : (data.sessions ?? []);
+        const normalized = list.map((s) => ({ ...s, id: s.id ?? s.sessionId ?? "" }));
+        setSessions(normalized);
+        if (normalized.length > 0) setSelectedId(normalized[0].id);
+        setLoadingSessions(false);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setError(e instanceof Error ? e.message : "Failed to load sessions");
+        setLoadingSessions(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!selectedId) {
+      setSteps([]);
+      return;
+    }
+    let cancelled = false;
+    setLoadingRun(true);
+    setError(null);
+    // Combine replay (context / step ordering) with traces (tool + memory detail).
+    Promise.all([
+      fetch(`/api/sessions/${selectedId}/replay`, { cache: "no-store" })
+        .then((r) => (r.ok ? r.json() : null))
+        .catch(() => null),
+      fetch(`/api/sessions/${selectedId}/traces`, { cache: "no-store" })
+        .then((r) => (r.ok ? r.json() : null))
+        .catch(() => null),
+    ])
+      .then(([replay, traces]) => {
+        if (cancelled) return;
+        const replaySteps = normalizeSteps(replay);
+        const traceSteps = normalizeSteps(traces);
+        // Prefer whichever source produced more steps.
+        setSteps(traceSteps.length >= replaySteps.length ? traceSteps : replaySteps);
+        setLoadingRun(false);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setError(e instanceof Error ? e.message : "Failed to load run");
+        setLoadingRun(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedId]);
+
+  return (
+    <div className="p-4 sm:p-6 space-y-4 sm:space-y-6 overflow-y-auto h-full">
+      {error && (
+        <div className="rounded-lg border border-yellow-500/30 bg-yellow-500/10 px-4 py-3 text-sm text-yellow-300">
+          {error}
+        </div>
+      )}
+
+      <div>
+        <h1 className="text-xl font-semibold text-white">Run Debugger</h1>
+        <p className="text-sm text-dark-400 mt-1">
+          Inspect assembled context, selected tools, tool args/results, and memory ops per step
+        </p>
+      </div>
+
+      <div className="flex items-center gap-3">
+        <label className="text-sm text-dark-400">Session</label>
+        <select
+          value={selectedId}
+          onChange={(e) => setSelectedId(e.target.value)}
+          disabled={loadingSessions}
+          className="px-3 py-2 text-sm bg-dark-800 border border-dark-700 rounded-lg text-dark-200 focus:outline-none focus:border-accent-500 max-w-md"
+        >
+          {sessions.length === 0 && <option value="">No sessions available</option>}
+          {sessions.map((session) => (
+            <option key={session.id} value={session.id}>
+              {sessionLabel(session)}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {loadingSessions ? (
+        <div className="rounded-xl border border-dark-700 bg-dark-800 px-5 py-12 text-center text-sm text-dark-400">
+          Loading sessions...
+        </div>
+      ) : loadingRun ? (
+        <div className="rounded-xl border border-dark-700 bg-dark-800 px-5 py-12 text-center text-sm text-dark-400">
+          Loading run trace...
+        </div>
+      ) : (
+        <RunDebugger steps={steps} />
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/dashboard/evals/[id]/page.tsx
+++ b/apps/web/app/dashboard/evals/[id]/page.tsx
@@ -1,0 +1,344 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+import {
+  ArrowLeft,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  CircleSlash,
+  Clock,
+  Coins,
+  Loader2,
+  TriangleAlert,
+} from "lucide-react";
+import { Badge } from "@/components/Badge";
+import { StatsCard } from "@/components/StatsCard";
+import { cn, formatCost, formatDate } from "@/lib/utils";
+
+type EvalStatus = "passed" | "failed" | "running" | "error";
+type CaseStatus = "passed" | "failed" | "error";
+
+interface EvalCase {
+  id: string;
+  name: string;
+  status: CaseStatus;
+  input: string;
+  expected: string | null;
+  actual: string | null;
+  scores: Record<string, number>;
+  durationMs: number;
+  costUsd: number;
+  error: string | null;
+}
+
+interface EvalRunDetail {
+  id: string;
+  suite: string;
+  status: EvalStatus;
+  model: string;
+  startedAt: number;
+  finishedAt: number | null;
+  durationMs: number | null;
+  totalCases: number;
+  passedCases: number;
+  failedCases: number;
+  score: number;
+  totalCostUsd: number;
+  cases: EvalCase[];
+}
+
+const statusVariant: Record<EvalStatus, "success" | "danger" | "info" | "warning"> = {
+  passed: "success",
+  failed: "danger",
+  running: "info",
+  error: "warning",
+};
+
+const caseVariant: Record<CaseStatus, "success" | "danger" | "warning"> = {
+  passed: "success",
+  failed: "danger",
+  error: "warning",
+};
+
+function runIcon(status: EvalStatus) {
+  switch (status) {
+    case "passed":
+      return <CheckCircle2 size={20} />;
+    case "failed":
+      return <CircleSlash size={20} />;
+    case "running":
+      return <Loader2 size={20} className="animate-spin" />;
+    default:
+      return <TriangleAlert size={20} />;
+  }
+}
+
+export default function EvalRunDetailPage() {
+  const params = useParams();
+  const id = params.id as string;
+  const [run, setRun] = useState<EvalRunDetail | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [statusFilter, setStatusFilter] = useState<"all" | CaseStatus>("all");
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchRun() {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const response = await fetch(`/api/evals/${id}`, { cache: "no-store" });
+
+        if (!response.ok) {
+          throw new Error(
+            response.status === 404
+              ? "Eval run not found"
+              : `Eval run request failed with ${response.status}`,
+          );
+        }
+
+        const payload = (await response.json()) as EvalRunDetail;
+        if (cancelled) return;
+        setRun(payload);
+      } catch (fetchError) {
+        if (cancelled) return;
+        setRun(null);
+        setError(
+          fetchError instanceof Error ? fetchError.message : "Failed to load eval run",
+        );
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    fetchRun();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  const cases = run?.cases ?? [];
+  const filteredCases = useMemo(
+    () =>
+      statusFilter === "all"
+        ? cases
+        : cases.filter((evalCase) => evalCase.status === statusFilter),
+    [cases, statusFilter],
+  );
+
+  const toggle = (caseId: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(caseId)) {
+        next.delete(caseId);
+      } else {
+        next.add(caseId);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <div className="p-4 sm:p-6 space-y-4 sm:space-y-6 overflow-y-auto h-full">
+      {error && (
+        <div className="rounded-lg border border-yellow-500/30 bg-yellow-500/10 px-4 py-3 text-sm text-yellow-300">
+          {error}
+        </div>
+      )}
+
+      <div className="flex items-start gap-4">
+        <Link
+          href="/dashboard/evals"
+          className="p-2 rounded-lg text-dark-400 hover:text-white hover:bg-dark-700 transition-colors mt-0.5"
+        >
+          <ArrowLeft size={18} />
+        </Link>
+        <div className="flex-1">
+          <div className="flex items-center gap-3">
+            <h1 className="text-xl font-semibold text-white">{run?.suite ?? id}</h1>
+            {run && (
+              <Badge variant={statusVariant[run.status] ?? "default"}>{run.status}</Badge>
+            )}
+          </div>
+          <p className="text-sm text-dark-400 mt-1 font-mono">{id}</p>
+        </div>
+      </div>
+
+      {isLoading ? (
+        <div className="rounded-xl border border-dark-700 bg-dark-800 px-5 py-12 text-center text-sm text-dark-400">
+          Loading eval run...
+        </div>
+      ) : !run ? (
+        <div className="rounded-xl border border-dark-700 bg-dark-800 px-5 py-12 text-center text-sm text-dark-400">
+          Eval run not found.
+        </div>
+      ) : (
+        <>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+            <StatsCard
+              title="Score"
+              value={`${(run.score * 100).toFixed(1)}%`}
+              icon={runIcon(run.status)}
+            />
+            <StatsCard
+              title="Cases"
+              value={`${run.passedCases}/${run.totalCases}`}
+              icon={<CheckCircle2 size={20} />}
+            />
+            <StatsCard
+              title="Duration"
+              value={run.durationMs == null ? "—" : `${(run.durationMs / 1000).toFixed(1)}s`}
+              icon={<Clock size={20} />}
+            />
+            <StatsCard
+              title="Cost"
+              value={formatCost(run.totalCostUsd)}
+              icon={<Coins size={20} />}
+            />
+          </div>
+
+          <div className="rounded-xl border border-dark-700 bg-dark-800 p-5">
+            <h3 className="text-sm font-medium text-white mb-4">Run Details</h3>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 text-sm">
+              <DetailRow label="Model" value={run.model} />
+              <DetailRow label="Started" value={formatDate(run.startedAt)} />
+              <DetailRow
+                label="Finished"
+                value={run.finishedAt == null ? "Running" : formatDate(run.finishedAt)}
+              />
+              <DetailRow
+                label="Passed / Failed"
+                value={`${run.passedCases} / ${run.failedCases}`}
+              />
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between gap-4">
+            <h3 className="text-sm font-medium text-white">
+              Cases <span className="text-dark-500">({filteredCases.length})</span>
+            </h3>
+            <select
+              value={statusFilter}
+              onChange={(event) =>
+                setStatusFilter(event.target.value as "all" | CaseStatus)
+              }
+              className="rounded-lg border border-dark-700 bg-dark-900 px-3 py-2 text-sm text-dark-200"
+            >
+              <option value="all">All Cases</option>
+              <option value="passed">Passed</option>
+              <option value="failed">Failed</option>
+              <option value="error">Error</option>
+            </select>
+          </div>
+
+          {filteredCases.length > 0 ? (
+            <div className="space-y-2">
+              {filteredCases.map((evalCase) => {
+                const isOpen = expanded.has(evalCase.id);
+                return (
+                  <div
+                    key={evalCase.id}
+                    className="rounded-xl border border-dark-700 bg-dark-800 overflow-hidden"
+                  >
+                    <button
+                      onClick={() => toggle(evalCase.id)}
+                      className="flex w-full items-center justify-between gap-4 px-4 py-3 text-left hover:bg-dark-700/40 transition-colors"
+                    >
+                      <div className="flex items-center gap-3 min-w-0">
+                        {isOpen ? (
+                          <ChevronDown size={16} className="text-dark-500 shrink-0" />
+                        ) : (
+                          <ChevronRight size={16} className="text-dark-500 shrink-0" />
+                        )}
+                        <Badge variant={caseVariant[evalCase.status] ?? "default"}>
+                          {evalCase.status}
+                        </Badge>
+                        <span className="text-sm font-medium text-white truncate">
+                          {evalCase.name}
+                        </span>
+                      </div>
+                      <div className="flex items-center gap-4 text-xs text-dark-400 shrink-0">
+                        <span>{(evalCase.durationMs / 1000).toFixed(1)}s</span>
+                        <span>{formatCost(evalCase.costUsd)}</span>
+                      </div>
+                    </button>
+
+                    {isOpen && (
+                      <div className="border-t border-dark-700 px-4 py-4 space-y-4">
+                        {Object.keys(evalCase.scores ?? {}).length > 0 && (
+                          <div className="flex flex-wrap gap-2">
+                            {Object.entries(evalCase.scores).map(([metric, value]) => (
+                              <span
+                                key={metric}
+                                className="inline-flex items-center gap-1 rounded-md bg-dark-900 border border-dark-700 px-2 py-1 text-xs text-dark-300"
+                              >
+                                <span className="text-dark-400">{metric}:</span>
+                                <span className="text-dark-100 font-medium">
+                                  {value.toFixed(2)}
+                                </span>
+                              </span>
+                            ))}
+                          </div>
+                        )}
+
+                        {evalCase.error && (
+                          <div className="rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-3 text-sm text-red-300 whitespace-pre-wrap break-words">
+                            {evalCase.error}
+                          </div>
+                        )}
+
+                        <CaseField label="Input" value={evalCase.input} />
+                        {evalCase.expected != null && (
+                          <CaseField label="Expected" value={evalCase.expected} />
+                        )}
+                        {evalCase.actual != null && (
+                          <CaseField label="Actual" value={evalCase.actual} />
+                        )}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <div className="rounded-xl border border-dark-700 bg-dark-800 px-5 py-12 text-center text-sm text-dark-400">
+              No cases match the current filter.
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="space-y-1">
+      <p className="text-xs text-dark-400">{label}</p>
+      <p className="text-dark-200 break-words">{value}</p>
+    </div>
+  );
+}
+
+function CaseField({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="space-y-1">
+      <p className="text-xs font-medium text-dark-400 uppercase tracking-wide">{label}</p>
+      <pre className={cn(
+        "rounded-lg bg-dark-900 border border-dark-700 px-3 py-2 text-xs text-dark-200",
+        "whitespace-pre-wrap break-words font-mono max-h-64 overflow-y-auto",
+      )}>
+        {value}
+      </pre>
+    </div>
+  );
+}

--- a/apps/web/app/dashboard/evals/page.tsx
+++ b/apps/web/app/dashboard/evals/page.tsx
@@ -1,0 +1,293 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import {
+  CheckCircle2,
+  CircleSlash,
+  Loader2,
+  RefreshCw,
+  TriangleAlert,
+} from "lucide-react";
+import { LineChart } from "@/components/Chart";
+import { StatsCard } from "@/components/StatsCard";
+import { Badge } from "@/components/Badge";
+import { DataTable, type Column } from "@/components/DataTable";
+import { cn, formatCost, formatDate } from "@/lib/utils";
+
+type EvalStatus = "passed" | "failed" | "running" | "error";
+type StatusFilter = "all" | EvalStatus;
+
+interface EvalRun {
+  id: string;
+  suite: string;
+  status: EvalStatus;
+  model: string;
+  startedAt: number;
+  finishedAt: number | null;
+  durationMs: number | null;
+  totalCases: number;
+  passedCases: number;
+  failedCases: number;
+  score: number;
+  totalCostUsd: number;
+}
+
+interface EvalsResponse {
+  runs?: EvalRun[];
+  total?: number;
+  hasMore?: boolean;
+}
+
+const statusVariant: Record<EvalStatus, "success" | "danger" | "info" | "warning"> = {
+  passed: "success",
+  failed: "danger",
+  running: "info",
+  error: "warning",
+};
+
+function statusIcon(status: EvalStatus) {
+  switch (status) {
+    case "passed":
+      return <CheckCircle2 size={14} className="text-success-400" />;
+    case "failed":
+      return <CircleSlash size={14} className="text-danger-400" />;
+    case "running":
+      return <Loader2 size={14} className="text-blue-400 animate-spin" />;
+    default:
+      return <TriangleAlert size={14} className="text-warning-400" />;
+  }
+}
+
+export default function EvalsPage() {
+  const router = useRouter();
+  const [runs, setRuns] = useState<EvalRun[]>([]);
+  const [total, setTotal] = useState(0);
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
+  const [isLoading, setIsLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchEvals() {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const query = statusFilter === "all" ? "" : `?status=${statusFilter}`;
+        const response = await fetch(`/api/evals${query}`, { cache: "no-store" });
+
+        if (!response.ok) {
+          throw new Error(`Evals request failed with ${response.status}`);
+        }
+
+        const payload = (await response.json()) as EvalsResponse;
+        if (cancelled) return;
+        setRuns(payload.runs ?? []);
+        setTotal(payload.total ?? (payload.runs ?? []).length);
+      } catch (fetchError) {
+        if (cancelled) return;
+        setRuns([]);
+        setTotal(0);
+        setError(
+          fetchError instanceof Error ? fetchError.message : "Failed to load eval runs",
+        );
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+          setIsRefreshing(false);
+        }
+      }
+    }
+
+    fetchEvals();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [statusFilter, refreshKey]);
+
+  const summary = useMemo(() => {
+    const finished = runs.filter((run) => run.status === "passed" || run.status === "failed");
+    const passed = runs.filter((run) => run.status === "passed").length;
+    const avgScore =
+      finished.length > 0
+        ? finished.reduce((sum, run) => sum + run.score, 0) / finished.length
+        : 0;
+    const totalCost = runs.reduce((sum, run) => sum + run.totalCostUsd, 0);
+    return { passed, avgScore, totalCost };
+  }, [runs]);
+
+  const trendData = useMemo(() => {
+    return [...runs]
+      .filter((run) => run.finishedAt !== null)
+      .sort((a, b) => (a.startedAt ?? 0) - (b.startedAt ?? 0))
+      .map((run) => ({
+        label: formatDate(run.startedAt, "MMM d HH:mm"),
+        score: Number((run.score * 100).toFixed(1)),
+      }));
+  }, [runs]);
+
+  const columns: Column<EvalRun>[] = [
+    {
+      key: "suite",
+      label: "Suite",
+      sortable: true,
+      render: (_value, row) => (
+        <div className="flex items-center gap-2">
+          {statusIcon(row.status)}
+          <span className="font-medium text-white">{row.suite}</span>
+        </div>
+      ),
+    },
+    {
+      key: "status",
+      label: "Status",
+      sortable: true,
+      render: (value) => (
+        <Badge variant={statusVariant[value as EvalStatus] ?? "default"}>
+          {String(value)}
+        </Badge>
+      ),
+    },
+    { key: "model", label: "Model", sortable: true },
+    {
+      key: "score",
+      label: "Score",
+      sortable: true,
+      render: (value) => `${((value as number) * 100).toFixed(1)}%`,
+    },
+    {
+      key: "passedCases",
+      label: "Cases",
+      render: (_value, row) => `${row.passedCases}/${row.totalCases}`,
+    },
+    {
+      key: "durationMs",
+      label: "Duration",
+      sortable: true,
+      render: (value) =>
+        value == null ? "—" : `${(((value as number) || 0) / 1000).toFixed(1)}s`,
+    },
+    {
+      key: "totalCostUsd",
+      label: "Cost",
+      sortable: true,
+      render: (value) => formatCost((value as number) ?? 0),
+    },
+    {
+      key: "startedAt",
+      label: "Started",
+      sortable: true,
+      render: (value) => formatDate(value as number),
+    },
+  ];
+
+  return (
+    <div className="p-4 sm:p-6 space-y-4 sm:space-y-6 overflow-y-auto h-full">
+      {error && (
+        <div className="rounded-lg border border-yellow-500/30 bg-yellow-500/10 px-4 py-3 text-sm text-yellow-300">
+          {error}
+        </div>
+      )}
+
+      <div className="flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
+        <div>
+          <h1 className="text-xl font-semibold text-white">Eval Results</h1>
+          <p className="text-sm text-dark-400 mt-1">
+            Eval suite runs with score trends and per-run drill-down
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <select
+            value={statusFilter}
+            onChange={(event) => setStatusFilter(event.target.value as StatusFilter)}
+            className="rounded-lg border border-dark-700 bg-dark-900 px-3 py-2 text-sm text-dark-200"
+          >
+            <option value="all">All Statuses</option>
+            <option value="passed">Passed</option>
+            <option value="failed">Failed</option>
+            <option value="running">Running</option>
+            <option value="error">Error</option>
+          </select>
+          <button
+            onClick={() => {
+              setIsRefreshing(true);
+              setRefreshKey((value) => value + 1);
+            }}
+            className="inline-flex items-center gap-2 rounded-lg bg-dark-700 px-3 py-1.5 text-xs font-medium text-dark-200 transition-colors hover:bg-dark-600"
+          >
+            <RefreshCw size={14} className={cn(isRefreshing && "animate-spin")} />
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        <StatsCard
+          title="Total Runs"
+          value={total.toLocaleString()}
+          icon={<CheckCircle2 size={20} />}
+        />
+        <StatsCard
+          title="Passed"
+          value={summary.passed.toLocaleString()}
+          icon={<CheckCircle2 size={20} />}
+        />
+        <StatsCard
+          title="Avg Score"
+          value={`${(summary.avgScore * 100).toFixed(1)}%`}
+          icon={<TriangleAlert size={20} />}
+        />
+        <StatsCard
+          title="Total Cost"
+          value={formatCost(summary.totalCost)}
+          icon={<CircleSlash size={20} />}
+        />
+      </div>
+
+      <div className="rounded-xl border border-dark-700 bg-dark-800 p-5">
+        <h3 className="text-sm font-medium text-white mb-4">Score Trend</h3>
+        {trendData.length > 0 ? (
+          <LineChart
+            data={trendData}
+            xKey="label"
+            yKeys={[{ key: "score", name: "Score (%)", color: "#22c55e" }]}
+            height={280}
+          />
+        ) : (
+          <div className="flex items-center justify-center h-[250px] rounded-lg bg-dark-700/30 text-sm text-dark-400">
+            No finished eval runs to chart yet.
+          </div>
+        )}
+      </div>
+
+      {isLoading ? (
+        <div className="rounded-xl border border-dark-700 bg-dark-800 px-5 py-12 text-center text-sm text-dark-400">
+          Loading eval runs...
+        </div>
+      ) : (
+        <DataTable
+          columns={columns}
+          data={runs}
+          keyField="id"
+          pageSize={15}
+          onRowClick={(row) => router.push(`/dashboard/evals/${row.id}`)}
+          emptyMessage="No eval runs match the current filter."
+        />
+      )}
+
+      <p className="text-xs text-dark-500">
+        Tip: click a row to open its{" "}
+        <Link href="/dashboard/evals" className="text-accent-400 hover:underline">
+          per-run detail
+        </Link>{" "}
+        with every case outcome.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/app/dashboard/sessions/[id]/replay/page.tsx
+++ b/apps/web/app/dashboard/sessions/[id]/replay/page.tsx
@@ -1,0 +1,369 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+import {
+  ArrowLeft,
+  Brain,
+  ChevronLeft,
+  ChevronRight,
+  Coins,
+  Eye,
+  Wrench,
+} from "lucide-react";
+import { Badge } from "@/components/Badge";
+import { cn, formatCost, formatDate, formatTokens } from "@/lib/utils";
+
+type ReplayEventType = "reason" | "act" | "observe";
+
+interface ReplayEvent {
+  index: number;
+  timestamp: number;
+  type: ReplayEventType;
+  content: string;
+  iteration: number;
+  toolName?: string;
+  toolCallId?: string;
+  arguments?: Record<string, unknown>;
+  result?: unknown;
+  durationMs?: number;
+  model?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+}
+
+interface ReplayResponse {
+  sessionId: string;
+  channelType: string;
+  startedAt: number;
+  endedAt: number;
+  events: ReplayEvent[];
+}
+
+const typeMeta: Record<
+  ReplayEventType,
+  { label: string; icon: React.ReactNode; variant: "info" | "success" | "warning"; accent: string }
+> = {
+  reason: {
+    label: "Reason",
+    icon: <Brain size={16} />,
+    variant: "info",
+    accent: "border-blue-500/40 bg-blue-500/5",
+  },
+  act: {
+    label: "Act",
+    icon: <Wrench size={16} />,
+    variant: "success",
+    accent: "border-green-500/40 bg-green-500/5",
+  },
+  observe: {
+    label: "Observe",
+    icon: <Eye size={16} />,
+    variant: "warning",
+    accent: "border-amber-500/40 bg-amber-500/5",
+  },
+};
+
+function stringify(value: unknown): string {
+  if (value == null) return "";
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+export default function SessionReplayPage() {
+  const params = useParams();
+  const id = params.id as string;
+  const [replay, setReplay] = useState<ReplayResponse | null>(null);
+  const [step, setStep] = useState(0);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchReplay() {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const response = await fetch(`/api/sessions/${id}/replay`, { cache: "no-store" });
+
+        if (!response.ok) {
+          throw new Error(
+            response.status === 404
+              ? "Session replay not found"
+              : `Replay request failed with ${response.status}`,
+          );
+        }
+
+        const payload = (await response.json()) as ReplayResponse;
+        if (cancelled) return;
+        setReplay(payload);
+        setStep(0);
+      } catch (fetchError) {
+        if (cancelled) return;
+        setReplay(null);
+        setError(
+          fetchError instanceof Error ? fetchError.message : "Failed to load replay",
+        );
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    fetchReplay();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  const events = useMemo(
+    () => [...(replay?.events ?? [])].sort((a, b) => a.index - b.index),
+    [replay],
+  );
+  const total = events.length;
+  const safeStep = Math.min(step, Math.max(0, total - 1));
+  const current = events[safeStep];
+
+  const runningCost = useMemo(() => {
+    return events
+      .slice(0, safeStep + 1)
+      .reduce((sum, event) => {
+        // Cost is not on replay events directly; approximate from token usage when present.
+        return sum;
+      }, 0);
+  }, [events, safeStep]);
+
+  const cumulativeTokens = useMemo(() => {
+    return events.slice(0, safeStep + 1).reduce(
+      (acc, event) => {
+        acc.input += event.inputTokens ?? 0;
+        acc.output += event.outputTokens ?? 0;
+        return acc;
+      },
+      { input: 0, output: 0 },
+    );
+  }, [events, safeStep]);
+
+  useEffect(() => {
+    function onKey(event: KeyboardEvent) {
+      if (event.key === "ArrowRight") {
+        setStep((value) => Math.min(value + 1, total - 1));
+      } else if (event.key === "ArrowLeft") {
+        setStep((value) => Math.max(value - 1, 0));
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [total]);
+
+  return (
+    <div className="p-4 sm:p-6 space-y-4 sm:space-y-6 overflow-y-auto h-full">
+      {error && (
+        <div className="rounded-lg border border-yellow-500/30 bg-yellow-500/10 px-4 py-3 text-sm text-yellow-300">
+          {error}
+        </div>
+      )}
+
+      <div className="flex items-start gap-4">
+        <Link
+          href={`/dashboard/sessions/${id}`}
+          className="p-2 rounded-lg text-dark-400 hover:text-white hover:bg-dark-700 transition-colors mt-0.5"
+        >
+          <ArrowLeft size={18} />
+        </Link>
+        <div className="flex-1">
+          <h1 className="text-xl font-semibold text-white">Session Replay</h1>
+          <p className="text-sm text-dark-400 mt-1 font-mono break-all">{id}</p>
+        </div>
+      </div>
+
+      {isLoading ? (
+        <div className="rounded-xl border border-dark-700 bg-dark-800 px-5 py-12 text-center text-sm text-dark-400">
+          Loading replay...
+        </div>
+      ) : total === 0 ? (
+        <div className="rounded-xl border border-dark-700 bg-dark-800 px-5 py-12 text-center text-sm text-dark-400">
+          No replay events are available for this session yet.
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 lg:grid-cols-[280px_minmax(0,1fr)] gap-6">
+          {/* Step list */}
+          <div className="space-y-2 lg:max-h-[70vh] lg:overflow-y-auto pr-1">
+            {events.map((event, idx) => {
+              const meta = typeMeta[event.type];
+              const isActive = idx === safeStep;
+              return (
+                <button
+                  key={`${event.index}-${event.timestamp}`}
+                  onClick={() => setStep(idx)}
+                  className={cn(
+                    "w-full rounded-lg border px-3 py-2 text-left transition-colors",
+                    isActive
+                      ? "border-accent-500 bg-accent-600/10"
+                      : "border-dark-700 bg-dark-800 hover:border-dark-600",
+                  )}
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="flex items-center gap-2 min-w-0">
+                      <span className="text-dark-400 shrink-0">{meta.icon}</span>
+                      <span className="text-xs font-medium text-white">{meta.label}</span>
+                      {event.toolName && (
+                        <span className="text-xs text-dark-400 truncate">
+                          {event.toolName}
+                        </span>
+                      )}
+                    </div>
+                    <span className="text-[10px] text-dark-500 shrink-0">#{idx + 1}</span>
+                  </div>
+                  <p className="mt-1 text-[11px] text-dark-500">
+                    iter {event.iteration} • {formatDate(event.timestamp, "HH:mm:ss")}
+                  </p>
+                </button>
+              );
+            })}
+          </div>
+
+          {/* Stepper + detail */}
+          <div className="space-y-4">
+            <div className="rounded-xl border border-dark-700 bg-dark-800 p-4">
+              <div className="flex items-center justify-between gap-4">
+                <button
+                  onClick={() => setStep((value) => Math.max(value - 1, 0))}
+                  disabled={safeStep === 0}
+                  className="inline-flex items-center gap-2 rounded-lg bg-dark-700 px-3 py-2 text-sm text-dark-200 transition-colors hover:bg-dark-600 disabled:opacity-30 disabled:cursor-not-allowed"
+                >
+                  <ChevronLeft size={16} /> Prev
+                </button>
+                <div className="text-center">
+                  <p className="text-sm font-medium text-white">
+                    Step {safeStep + 1} / {total}
+                  </p>
+                  <p className="text-xs text-dark-500">Use ← → arrow keys to navigate</p>
+                </div>
+                <button
+                  onClick={() => setStep((value) => Math.min(value + 1, total - 1))}
+                  disabled={safeStep >= total - 1}
+                  className="inline-flex items-center gap-2 rounded-lg bg-dark-700 px-3 py-2 text-sm text-dark-200 transition-colors hover:bg-dark-600 disabled:opacity-30 disabled:cursor-not-allowed"
+                >
+                  Next <ChevronRight size={16} />
+                </button>
+              </div>
+
+              {/* Progress bar */}
+              <div className="mt-3 h-1.5 rounded-full bg-dark-900 overflow-hidden">
+                <div
+                  className="h-full bg-accent-500 transition-all"
+                  style={{ width: `${((safeStep + 1) / total) * 100}%` }}
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+              <RunningStat
+                label="Cumulative Tokens"
+                value={formatTokens(cumulativeTokens.input + cumulativeTokens.output)}
+              />
+              <RunningStat
+                label="In / Out Tokens"
+                value={`${formatTokens(cumulativeTokens.input)} / ${formatTokens(cumulativeTokens.output)}`}
+              />
+              <RunningStat
+                label="Running Cost"
+                value={formatCost(runningCost)}
+                icon={<Coins size={14} />}
+              />
+            </div>
+
+            {current && (
+              <div className={cn("rounded-xl border p-5 space-y-4", typeMeta[current.type].accent)}>
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div className="flex items-center gap-2">
+                    <span className="text-dark-300">{typeMeta[current.type].icon}</span>
+                    <Badge variant={typeMeta[current.type].variant}>
+                      {typeMeta[current.type].label}
+                    </Badge>
+                    {current.toolName && (
+                      <span className="text-sm text-dark-200 font-mono">{current.toolName}</span>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-3 text-xs text-dark-400">
+                    <span>iteration {current.iteration}</span>
+                    {current.durationMs != null && <span>{Math.round(current.durationMs)}ms</span>}
+                    {current.model && <span>{current.model}</span>}
+                    <span>{formatDate(current.timestamp, "HH:mm:ss")}</span>
+                  </div>
+                </div>
+
+                {current.content && (
+                  <div className="text-sm text-dark-200 whitespace-pre-wrap break-words">
+                    {current.content}
+                  </div>
+                )}
+
+                {(current.inputTokens != null || current.outputTokens != null) && (
+                  <div className="flex gap-3 text-xs text-dark-400">
+                    {current.inputTokens != null && (
+                      <span>In: {formatTokens(current.inputTokens)}</span>
+                    )}
+                    {current.outputTokens != null && (
+                      <span>Out: {formatTokens(current.outputTokens)}</span>
+                    )}
+                  </div>
+                )}
+
+                {current.arguments && Object.keys(current.arguments).length > 0 && (
+                  <Section label="Tool Arguments" value={stringify(current.arguments)} />
+                )}
+
+                {current.result !== undefined && (
+                  <Section label="Tool Result" value={stringify(current.result)} />
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function RunningStat({
+  label,
+  value,
+  icon,
+}: {
+  label: string;
+  value: string;
+  icon?: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-xl border border-dark-700 bg-dark-800 p-4">
+      <div className="flex items-center gap-2 text-dark-400">
+        {icon}
+        <p className="text-xs">{label}</p>
+      </div>
+      <p className="mt-2 text-lg font-semibold text-white">{value}</p>
+    </div>
+  );
+}
+
+function Section({ label, value }: { label: string; value: string }) {
+  if (!value) return null;
+  return (
+    <div className="space-y-1">
+      <p className="text-xs font-medium text-dark-400 uppercase tracking-wide">{label}</p>
+      <pre className="rounded-lg bg-dark-900 border border-dark-700 px-3 py-2 text-xs text-dark-200 whitespace-pre-wrap break-words font-mono max-h-64 overflow-y-auto">
+        {value}
+      </pre>
+    </div>
+  );
+}

--- a/apps/web/app/dashboard/timeline/page.tsx
+++ b/apps/web/app/dashboard/timeline/page.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Activity, Coins, Hash, Pause, Play, Sparkles } from "lucide-react";
+import { StatsCard } from "@/components/StatsCard";
+import { RunTimeline, type AgentRun } from "@/components/RunTimeline";
+import { cn, formatCost, formatTokens } from "@/lib/utils";
+
+interface TraceListResponse {
+  traces?: AgentRun[];
+  total?: number;
+  active?: number;
+}
+
+const POLL_INTERVAL_MS = 3000;
+const WINDOW_MS = 3_600_000; // last hour
+
+export default function TimelinePage() {
+  const [runs, setRuns] = useState<AgentRun[]>([]);
+  const [activeCount, setActiveCount] = useState(0);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [live, setLive] = useState(true);
+  const [lastUpdated, setLastUpdated] = useState<number | null>(null);
+  const initialLoad = useRef(true);
+
+  const fetchRuns = useCallback(async () => {
+    const since = Date.now() - WINDOW_MS;
+    try {
+      const response = await fetch(
+        `/api/traces?includeActive=true&limit=60&since=${since}`,
+        { cache: "no-store" },
+      );
+      if (!response.ok) {
+        throw new Error(`Traces request failed with ${response.status}`);
+      }
+      const payload = (await response.json()) as TraceListResponse;
+      const nextRuns = payload.traces ?? [];
+      setRuns(nextRuns);
+      setActiveCount(
+        payload.active ??
+          nextRuns.filter((run) => run.endedAt === undefined).length,
+      );
+      setError(null);
+      setLastUpdated(Date.now());
+    } catch (fetchError) {
+      setError(
+        fetchError instanceof Error ? fetchError.message : "Failed to load runs",
+      );
+    } finally {
+      if (initialLoad.current) {
+        initialLoad.current = false;
+        setIsLoading(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchRuns();
+  }, [fetchRuns]);
+
+  useEffect(() => {
+    if (!live) return;
+    const timer = setInterval(fetchRuns, POLL_INTERVAL_MS);
+    return () => clearInterval(timer);
+  }, [live, fetchRuns]);
+
+  const runningCost = runs.reduce((sum, run) => sum + run.costUsd, 0);
+  const runningTokens = runs.reduce(
+    (sum, run) => sum + run.inputTokens + run.outputTokens,
+    0,
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-full text-dark-400">
+        Loading timeline...
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4 sm:p-6 space-y-4 sm:space-y-6 overflow-y-auto h-full">
+      {error && (
+        <div className="rounded-lg border border-yellow-500/30 bg-yellow-500/10 px-4 py-3 text-sm text-yellow-300">
+          {error}
+        </div>
+      )}
+
+      <div className="flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
+        <div>
+          <h1 className="text-xl font-semibold text-white">Run Timeline</h1>
+          <p className="text-sm text-dark-400 mt-1">
+            Live agent runs with current phase, active tool, and running cost
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          {lastUpdated && (
+            <span className="text-xs text-dark-500">
+              updated {new Date(lastUpdated).toLocaleTimeString()}
+            </span>
+          )}
+          <button
+            onClick={() => setLive((value) => !value)}
+            className={cn(
+              "inline-flex items-center gap-2 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors",
+              live
+                ? "bg-accent-600 text-white hover:bg-accent-500"
+                : "bg-dark-700 text-dark-200 hover:bg-dark-600",
+            )}
+          >
+            {live ? <Pause size={14} /> : <Play size={14} />}
+            {live ? "Live" : "Paused"}
+          </button>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        <StatsCard
+          title="Active Runs"
+          value={activeCount.toLocaleString()}
+          icon={<Sparkles size={20} />}
+        />
+        <StatsCard
+          title="Runs (1h)"
+          value={runs.length.toLocaleString()}
+          icon={<Activity size={20} />}
+        />
+        <StatsCard
+          title="Tokens (1h)"
+          value={formatTokens(runningTokens)}
+          icon={<Hash size={20} />}
+        />
+        <StatsCard
+          title="Cost (1h)"
+          value={formatCost(runningCost)}
+          icon={<Coins size={20} />}
+        />
+      </div>
+
+      <RunTimeline runs={runs} />
+    </div>
+  );
+}

--- a/apps/web/app/dashboard/usage/page.tsx
+++ b/apps/web/app/dashboard/usage/page.tsx
@@ -1,0 +1,403 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  Calendar,
+  Coins,
+  Hash,
+  MessageSquare,
+  RefreshCw,
+  Users,
+} from "lucide-react";
+import { BarChart, LineChart, PieChart } from "@/components/Chart";
+import { StatsCard } from "@/components/StatsCard";
+import { Badge } from "@/components/Badge";
+import { cn, formatCost, formatDate, formatTokens } from "@/lib/utils";
+
+type RangeKey = "24h" | "7d" | "30d" | "90d";
+
+interface UsageResponse {
+  range?: {
+    from?: number;
+    to?: number;
+    granularity?: "hour" | "day" | "week";
+  };
+  summary?: {
+    totalTokens?: number;
+    totalInputTokens?: number;
+    totalOutputTokens?: number;
+    totalCostUsd?: number;
+    totalMessages?: number;
+    activeUsers?: number;
+  };
+  timeSeries?: Array<{
+    timestamp: number;
+    tokens: number;
+    costUsd: number;
+    messages: number;
+  }>;
+  byModel?: Array<{ model: string; tokens: number; costUsd: number; messages: number }>;
+  byUser?: Array<{ userId: string; tokens: number; costUsd: number; messages: number }>;
+  byChannel?: Array<{ channel: string; tokens: number; costUsd: number; messages: number }>;
+}
+
+const RANGE_MS: Record<RangeKey, number> = {
+  "24h": 86_400_000,
+  "7d": 604_800_000,
+  "30d": 2_592_000_000,
+  "90d": 7_776_000_000,
+};
+
+const RANGE_GRANULARITY: Record<RangeKey, "hour" | "day" | "week"> = {
+  "24h": "hour",
+  "7d": "day",
+  "30d": "day",
+  "90d": "week",
+};
+
+const RANGE_LABELS: Record<RangeKey, string> = {
+  "24h": "24 Hours",
+  "7d": "7 Days",
+  "30d": "30 Days",
+  "90d": "90 Days",
+};
+
+function emptyUsage(): UsageResponse {
+  return {
+    range: { from: 0, to: 0, granularity: "day" },
+    summary: {
+      totalTokens: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalCostUsd: 0,
+      totalMessages: 0,
+      activeUsers: 0,
+    },
+    timeSeries: [],
+    byModel: [],
+    byUser: [],
+    byChannel: [],
+  };
+}
+
+function humanizeKey(value: string): string {
+  return value
+    .split(/[_-]/g)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+export default function UsagePage() {
+  const [range, setRange] = useState<RangeKey>("7d");
+  const [usage, setUsage] = useState<UsageResponse>(emptyUsage);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    const to = Date.now();
+    const from = to - RANGE_MS[range];
+    const granularity = RANGE_GRANULARITY[range];
+
+    async function fetchUsage() {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const response = await fetch(
+          `/api/usage?from=${from}&to=${to}&granularity=${granularity}`,
+          { cache: "no-store" },
+        );
+
+        if (!response.ok) {
+          throw new Error(`Usage request failed with ${response.status}`);
+        }
+
+        const payload = (await response.json()) as UsageResponse;
+        if (cancelled) return;
+        setUsage(payload);
+      } catch (fetchError) {
+        if (cancelled) return;
+        setUsage(emptyUsage());
+        setError(
+          fetchError instanceof Error
+            ? fetchError.message
+            : "Failed to load usage data",
+        );
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+          setIsRefreshing(false);
+        }
+      }
+    }
+
+    fetchUsage();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [range, refreshKey]);
+
+  const summary = usage.summary ?? emptyUsage().summary!;
+  const granularity = usage.range?.granularity ?? RANGE_GRANULARITY[range];
+
+  const seriesData = useMemo(() => {
+    const pattern = granularity === "hour" ? "MMM d HH:mm" : granularity === "week" ? "MMM d" : "MMM d";
+    return (usage.timeSeries ?? []).map((point) => ({
+      label: formatDate(point.timestamp, pattern),
+      tokens: point.tokens,
+      cost: Number(point.costUsd.toFixed(4)),
+      messages: point.messages,
+    }));
+  }, [usage.timeSeries, granularity]);
+
+  const byModelData = (usage.byModel ?? [])
+    .map((row) => ({
+      model: row.model,
+      tokens: row.tokens,
+      cost: Number(row.costUsd.toFixed(4)),
+      messages: row.messages,
+    }))
+    .sort((a, b) => b.tokens - a.tokens);
+
+  const byChannelData = (usage.byChannel ?? [])
+    .filter((row) => row.tokens > 0 || row.messages > 0)
+    .map((row) => ({
+      channel: humanizeKey(row.channel),
+      tokens: row.tokens,
+    }))
+    .sort((a, b) => b.tokens - a.tokens);
+
+  const byUserData = (usage.byUser ?? [])
+    .map((row) => ({ ...row }))
+    .sort((a, b) => b.tokens - a.tokens)
+    .slice(0, 10);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-full text-dark-400">
+        Loading usage...
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4 sm:p-6 space-y-4 sm:space-y-6 overflow-y-auto h-full">
+      {error && (
+        <div className="rounded-lg border border-yellow-500/30 bg-yellow-500/10 px-4 py-3 text-sm text-yellow-300">
+          {error}
+        </div>
+      )}
+
+      <div className="flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
+        <div>
+          <h1 className="text-xl font-semibold text-white">Token &amp; Cost Usage</h1>
+          <p className="text-sm text-dark-400 mt-1">
+            Token and cost breakdown by model, channel, user, and time
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Calendar size={16} className="text-dark-400" />
+          {(Object.keys(RANGE_LABELS) as RangeKey[]).map((option) => (
+            <button
+              key={option}
+              onClick={() => setRange(option)}
+              className={cn(
+                "px-3 py-1.5 text-xs font-medium rounded-lg transition-colors",
+                range === option
+                  ? "bg-accent-600 text-white"
+                  : "bg-dark-700 text-dark-400 hover:text-white",
+              )}
+            >
+              {RANGE_LABELS[option]}
+            </button>
+          ))}
+          <button
+            onClick={() => {
+              setIsRefreshing(true);
+              setRefreshKey((value) => value + 1);
+            }}
+            className="inline-flex items-center gap-2 rounded-lg bg-dark-700 px-3 py-1.5 text-xs font-medium text-dark-200 transition-colors hover:bg-dark-600"
+          >
+            <RefreshCw size={14} className={cn(isRefreshing && "animate-spin")} />
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        <StatsCard
+          title="Total Tokens"
+          value={formatTokens(summary.totalTokens ?? 0)}
+          icon={<Hash size={20} />}
+        />
+        <StatsCard
+          title="Total Cost"
+          value={formatCost(summary.totalCostUsd ?? 0)}
+          icon={<Coins size={20} />}
+        />
+        <StatsCard
+          title="Messages"
+          value={(summary.totalMessages ?? 0).toLocaleString()}
+          icon={<MessageSquare size={20} />}
+        />
+        <StatsCard
+          title="Active Users"
+          value={(summary.activeUsers ?? 0).toLocaleString()}
+          icon={<Users size={20} />}
+        />
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div className="rounded-xl border border-dark-700 bg-dark-800 p-4">
+          <p className="text-sm text-dark-400">Input Tokens</p>
+          <p className="mt-2 text-xl font-semibold text-white">
+            {formatTokens(summary.totalInputTokens ?? 0)}
+          </p>
+        </div>
+        <div className="rounded-xl border border-dark-700 bg-dark-800 p-4">
+          <p className="text-sm text-dark-400">Output Tokens</p>
+          <p className="mt-2 text-xl font-semibold text-white">
+            {formatTokens(summary.totalOutputTokens ?? 0)}
+          </p>
+        </div>
+        <div className="rounded-xl border border-dark-700 bg-dark-800 p-4">
+          <p className="text-sm text-dark-400">Granularity</p>
+          <p className="mt-2 text-xl font-semibold text-white capitalize">{granularity}</p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div className="rounded-xl border border-dark-700 bg-dark-800 p-5">
+          <h3 className="text-sm font-medium text-white mb-4">Tokens over Time</h3>
+          {seriesData.length > 0 ? (
+            <LineChart
+              data={seriesData}
+              xKey="label"
+              yKeys={[{ key: "tokens", name: "Tokens", color: "#22c55e" }]}
+              height={280}
+            />
+          ) : (
+            <EmptyChart label="No token usage recorded in this window." />
+          )}
+        </div>
+        <div className="rounded-xl border border-dark-700 bg-dark-800 p-5">
+          <h3 className="text-sm font-medium text-white mb-4">Cost over Time</h3>
+          {seriesData.length > 0 ? (
+            <LineChart
+              data={seriesData}
+              xKey="label"
+              yKeys={[{ key: "cost", name: "Cost ($)", color: "#f59e0b" }]}
+              height={280}
+            />
+          ) : (
+            <EmptyChart label="No cost data recorded in this window." />
+          )}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div className="rounded-xl border border-dark-700 bg-dark-800 p-5">
+          <div className="flex items-center justify-between mb-4">
+            <h3 className="text-sm font-medium text-white">Tokens by Model</h3>
+            <Badge variant="accent">{byModelData.length} models</Badge>
+          </div>
+          {byModelData.length > 0 ? (
+            <BarChart
+              data={byModelData}
+              xKey="model"
+              yKeys={[{ key: "tokens", name: "Tokens", color: "#6366f1" }]}
+              height={280}
+            />
+          ) : (
+            <EmptyChart label="No per-model usage in this range." />
+          )}
+        </div>
+        <div className="rounded-xl border border-dark-700 bg-dark-800 p-5">
+          <div className="flex items-center justify-between mb-4">
+            <h3 className="text-sm font-medium text-white">Tokens by Channel</h3>
+            <Badge variant="info">{byChannelData.length} channels</Badge>
+          </div>
+          {byChannelData.length > 0 ? (
+            <PieChart
+              data={byChannelData}
+              dataKey="tokens"
+              nameKey="channel"
+              height={280}
+            />
+          ) : (
+            <EmptyChart label="No per-channel usage in this range." />
+          )}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+        <div className="rounded-xl border border-dark-700 bg-dark-800 p-5">
+          <h3 className="text-sm font-medium text-white mb-4">Cost by Model</h3>
+          {byModelData.length > 0 ? (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-dark-700">
+                    <th className="px-4 py-3 text-left text-xs font-medium text-dark-400 uppercase">Model</th>
+                    <th className="px-4 py-3 text-right text-xs font-medium text-dark-400 uppercase">Tokens</th>
+                    <th className="px-4 py-3 text-right text-xs font-medium text-dark-400 uppercase">Messages</th>
+                    <th className="px-4 py-3 text-right text-xs font-medium text-dark-400 uppercase">Cost</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-dark-700/50">
+                  {byModelData.map((row) => (
+                    <tr key={row.model}>
+                      <td className="px-4 py-3 text-dark-200 font-medium">{row.model}</td>
+                      <td className="px-4 py-3 text-right text-dark-300">{formatTokens(row.tokens)}</td>
+                      <td className="px-4 py-3 text-right text-dark-300">{row.messages.toLocaleString()}</td>
+                      <td className="px-4 py-3 text-right text-dark-300">{formatCost(row.cost)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <EmptyChart label="No per-model cost in this range." />
+          )}
+        </div>
+
+        <div className="rounded-xl border border-dark-700 bg-dark-800 p-5">
+          <h3 className="text-sm font-medium text-white mb-4">Top Users</h3>
+          {byUserData.length > 0 ? (
+            <div className="space-y-3">
+              {byUserData.map((user) => (
+                <div
+                  key={user.userId}
+                  className="flex items-center justify-between rounded-lg border border-dark-700 bg-dark-900/40 px-4 py-3"
+                >
+                  <div className="space-y-1 min-w-0">
+                    <p className="text-sm font-medium text-white truncate font-mono">{user.userId}</p>
+                    <p className="text-xs text-dark-400">
+                      {formatTokens(user.tokens)} tokens • {user.messages.toLocaleString()} messages
+                    </p>
+                  </div>
+                  <p className="text-sm text-dark-200 shrink-0">{formatCost(user.costUsd)}</p>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <EmptyChart label="No per-user usage in this range." />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function EmptyChart({ label }: { label: string }) {
+  return (
+    <div className="flex items-center justify-center h-[250px] rounded-lg bg-dark-700/30 text-sm text-dark-400">
+      {label}
+    </div>
+  );
+}

--- a/apps/web/app/marketplace/[id]/page.tsx
+++ b/apps/web/app/marketplace/[id]/page.tsx
@@ -18,8 +18,11 @@ import {
   Mail,
   Shield,
   Terminal,
+  Download,
+  Check,
 } from "lucide-react";
 import { Badge } from "@/components/Badge";
+import { Modal } from "@/components/Modal";
 
 interface SkillDetail {
   id: string;
@@ -92,12 +95,30 @@ function riskVariant(riskLevel?: string) {
   }
 }
 
+// Surface the permissions an install would grant: tools it requires + the
+// distinct risk levels of the actions it can perform.
+function derivePermissions(skill: SkillDetail): Array<{ label: string; risk?: string }> {
+  const perms: Array<{ label: string; risk?: string }> = [];
+  for (const tool of skill.requiredTools) {
+    perms.push({ label: `tool: ${tool}` });
+  }
+  for (const action of skill.actionDefinitions) {
+    if (action.riskLevel && action.riskLevel !== "low") {
+      perms.push({ label: `action: ${action.name}`, risk: action.riskLevel });
+    }
+  }
+  return perms;
+}
+
 export default function SkillDetailPage() {
   const params = useParams();
   const id = params.id as string;
   const [skill, setSkill] = useState<SkillDetail | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [confirmInstall, setConfirmInstall] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -137,6 +158,31 @@ export default function SkillDetailPage() {
     };
   }, [id]);
 
+  async function performInstall(enabled: boolean) {
+    if (!skill) return;
+    setBusy(true);
+    setActionError(null);
+    try {
+      const response = await fetch(`/api/marketplace/${skill.id}/install`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ id: skill.id, enabled }),
+      });
+      if (!response.ok) {
+        const data = (await response.json().catch(() => ({}))) as { error?: string };
+        throw new Error(data.error ?? `Request failed with ${response.status}`);
+      }
+      setSkill((prev) => (prev ? { ...prev, enabled } : prev));
+      setConfirmInstall(false);
+    } catch (e) {
+      setActionError(e instanceof Error ? e.message : "Action failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const permissions = skill ? derivePermissions(skill) : [];
+
   return (
     <div className="p-4 sm:p-6 space-y-6 overflow-y-auto h-full">
       <Link
@@ -150,6 +196,12 @@ export default function SkillDetailPage() {
       {error && (
         <div className="rounded-lg border border-yellow-500/30 bg-yellow-500/10 px-4 py-3 text-sm text-yellow-300">
           {error}
+        </div>
+      )}
+
+      {actionError && (
+        <div className="rounded-lg border border-danger-500/30 bg-danger-500/10 px-4 py-3 text-sm text-danger-400">
+          {actionError}
         </div>
       )}
 
@@ -175,7 +227,7 @@ export default function SkillDetailPage() {
                   {skill.source}
                 </Badge>
                 <Badge variant={skill.enabled ? "success" : "default"}>
-                  {skill.enabled ? "enabled" : "disabled"}
+                  {skill.enabled ? "installed" : "available"}
                 </Badge>
                 {skill.category && <Badge variant="default">{skill.category}</Badge>}
               </div>
@@ -184,16 +236,59 @@ export default function SkillDetailPage() {
               </p>
               <p className="text-sm text-dark-300 leading-relaxed">{skill.description}</p>
             </div>
-            <div className="grid grid-cols-2 gap-3 shrink-0 w-full sm:w-auto">
-              <div className="rounded-lg bg-dark-700/50 px-4 py-3">
-                <p className="text-xs text-dark-400">Actions</p>
-                <p className="text-lg font-semibold text-white">{skill.actions}</p>
-              </div>
-              <div className="rounded-lg bg-dark-700/50 px-4 py-3">
-                <p className="text-xs text-dark-400">Triggers</p>
-                <p className="text-lg font-semibold text-white">{skill.triggers}</p>
+            <div className="flex flex-col items-stretch gap-3 shrink-0 w-full sm:w-48">
+              {skill.enabled ? (
+                <button
+                  onClick={() => performInstall(false)}
+                  disabled={busy}
+                  className="flex items-center justify-center gap-2 rounded-lg bg-dark-700 px-4 py-2 text-sm font-medium text-white hover:bg-dark-600 disabled:opacity-50 transition-colors"
+                >
+                  <Check size={16} />
+                  {busy ? "Working..." : "Disable"}
+                </button>
+              ) : (
+                <button
+                  onClick={() => setConfirmInstall(true)}
+                  disabled={busy}
+                  className="flex items-center justify-center gap-2 rounded-lg bg-accent-600 px-4 py-2 text-sm font-medium text-white hover:bg-accent-500 disabled:opacity-50 transition-colors"
+                >
+                  <Download size={16} />
+                  Install &amp; Enable
+                </button>
+              )}
+              <div className="grid grid-cols-2 gap-3">
+                <div className="rounded-lg bg-dark-700/50 px-4 py-3">
+                  <p className="text-xs text-dark-400">Actions</p>
+                  <p className="text-lg font-semibold text-white">{skill.actions}</p>
+                </div>
+                <div className="rounded-lg bg-dark-700/50 px-4 py-3">
+                  <p className="text-xs text-dark-400">Triggers</p>
+                  <p className="text-lg font-semibold text-white">{skill.triggers}</p>
+                </div>
               </div>
             </div>
+          </div>
+
+          <div className="rounded-xl border border-dark-700 bg-dark-800 p-6">
+            <h2 className="text-sm font-medium text-white mb-3">Permissions</h2>
+            {permissions.length ? (
+              <ul className="space-y-2">
+                {permissions.map((perm) => (
+                  <li key={perm.label} className="flex items-center gap-2 text-sm text-dark-300">
+                    {perm.risk ? (
+                      <Badge variant={riskVariant(perm.risk)}>{perm.risk}</Badge>
+                    ) : (
+                      <Badge variant="info">required</Badge>
+                    )}
+                    <code className="text-xs text-dark-200">{perm.label}</code>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-sm text-dark-400">
+                This skill requests no elevated permissions.
+              </p>
+            )}
           </div>
 
           <div className="rounded-xl border border-dark-700 bg-dark-800 p-6">
@@ -307,6 +402,50 @@ export default function SkillDetailPage() {
               <p className="text-sm text-dark-400">No tags published.</p>
             )}
           </div>
+
+          <Modal
+            open={confirmInstall}
+            onClose={() => setConfirmInstall(false)}
+            title={`Install ${skill.name}?`}
+            size="md"
+          >
+            <p className="text-sm text-dark-300 mb-4">
+              This skill will be installed and enabled for your agent
+              {permissions.length > 0
+                ? ", granting the permissions below."
+                : "."}
+            </p>
+            {permissions.length > 0 && (
+              <ul className="mb-4 space-y-2">
+                {permissions.map((perm) => (
+                  <li key={perm.label} className="flex items-center gap-2 text-sm text-dark-300">
+                    {perm.risk ? (
+                      <Badge variant={riskVariant(perm.risk)}>{perm.risk}</Badge>
+                    ) : (
+                      <Badge variant="info">required</Badge>
+                    )}
+                    <code className="text-xs text-dark-200">{perm.label}</code>
+                  </li>
+                ))}
+              </ul>
+            )}
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() => setConfirmInstall(false)}
+                disabled={busy}
+                className="rounded-lg bg-dark-700 px-4 py-2 text-sm text-white hover:bg-dark-600 disabled:opacity-50 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => performInstall(true)}
+                disabled={busy}
+                className="rounded-lg bg-accent-600 px-4 py-2 text-sm font-medium text-white hover:bg-accent-500 disabled:opacity-50 transition-colors"
+              >
+                {busy ? "Installing..." : "Confirm install"}
+              </button>
+            </div>
+          </Modal>
         </>
       )}
     </div>

--- a/apps/web/app/marketplace/page.tsx
+++ b/apps/web/app/marketplace/page.tsx
@@ -70,6 +70,7 @@ export default function MarketplacePage() {
   const [search, setSearch] = useState("");
   const [categoryFilter, setCategoryFilter] = useState("");
   const [sourceFilter, setSourceFilter] = useState("");
+  const [statusFilter, setStatusFilter] = useState("");
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -121,6 +122,8 @@ export default function MarketplacePage() {
       skills.filter((skill) => {
         if (categoryFilter && skill.category !== categoryFilter) return false;
         if (sourceFilter && skill.source !== sourceFilter) return false;
+        if (statusFilter === "enabled" && !skill.enabled) return false;
+        if (statusFilter === "available" && skill.enabled) return false;
         if (search) {
           const q = search.toLowerCase();
           return (
@@ -131,7 +134,7 @@ export default function MarketplacePage() {
         }
         return true;
       }),
-    [categoryFilter, search, skills, sourceFilter],
+    [categoryFilter, search, skills, sourceFilter, statusFilter],
   );
 
   return (
@@ -145,7 +148,7 @@ export default function MarketplacePage() {
       <div>
         <h1 className="text-xl font-semibold text-white">KarnaHub Skill Catalog</h1>
         <p className="text-sm text-dark-400 mt-1">
-          Browse the live built-in and community skill inventory from the gateway
+          Browse, install, and enable built-in and community skills for your agent
         </p>
       </div>
 
@@ -202,6 +205,15 @@ export default function MarketplacePage() {
           <option value="">All Sources</option>
           <option value="builtin">Built-in</option>
           <option value="community">Community</option>
+        </select>
+        <select
+          value={statusFilter}
+          onChange={(e) => setStatusFilter(e.target.value)}
+          className="px-3 py-2 text-sm bg-dark-800 border border-dark-700 rounded-lg text-dark-200 focus:outline-none focus:border-accent-500"
+        >
+          <option value="">All Status</option>
+          <option value="enabled">Enabled</option>
+          <option value="available">Available</option>
         </select>
       </div>
 
@@ -262,7 +274,7 @@ export default function MarketplacePage() {
                   <span className="text-dark-500">v{skill.version}</span>
                 </div>
                 <Badge variant={skill.enabled ? "success" : "default"}>
-                  {skill.enabled ? "enabled" : "disabled"}
+                  {skill.enabled ? "installed" : "available"}
                 </Badge>
               </div>
             </Link>

--- a/apps/web/components/RunDebugger.tsx
+++ b/apps/web/components/RunDebugger.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { cn } from "@/lib/utils";
+import { Badge } from "@/components/Badge";
+import {
+  filterByPhase,
+  formatValue,
+  phasesPresent,
+  type RunStep,
+  type StepPhase,
+} from "@/components/runTrace";
+
+const phaseVariant: Record<
+  StepPhase,
+  "default" | "success" | "warning" | "danger" | "info" | "accent"
+> = {
+  context: "info",
+  "tool-selection": "accent",
+  model: "default",
+  "tool-call": "warning",
+  memory: "success",
+  response: "default",
+  other: "default",
+};
+
+export function RunDebugger({ steps }: { steps: RunStep[] }) {
+  const [phase, setPhase] = useState<StepPhase | "all">("all");
+  const [expanded, setExpanded] = useState<Set<number>>(new Set());
+
+  const phases = useMemo(() => phasesPresent(steps), [steps]);
+  const visible = useMemo(() => filterByPhase(steps, phase), [steps, phase]);
+
+  function toggle(index: number) {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(index)) next.delete(index);
+      else next.add(index);
+      return next;
+    });
+  }
+
+  if (steps.length === 0) {
+    return (
+      <div className="rounded-xl border border-dark-700 bg-dark-800 px-5 py-12 text-center text-sm text-dark-400">
+        No trace steps for this run.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap gap-2">
+        <FilterChip
+          label={`All (${steps.length})`}
+          active={phase === "all"}
+          onClick={() => setPhase("all")}
+        />
+        {phases.map((p) => (
+          <FilterChip
+            key={p}
+            label={p}
+            active={phase === p}
+            onClick={() => setPhase(p)}
+          />
+        ))}
+      </div>
+
+      <div className="space-y-3">
+        {visible.map((step) => {
+          const open = expanded.has(step.index);
+          return (
+            <div
+              key={step.index}
+              className="rounded-xl border border-dark-700 bg-dark-800"
+            >
+              <button
+                onClick={() => toggle(step.index)}
+                className="flex w-full items-center justify-between gap-3 px-5 py-3.5 text-left"
+              >
+                <div className="flex items-center gap-3">
+                  <span className="font-mono text-xs text-dark-500">#{step.index}</span>
+                  <Badge variant={phaseVariant[step.phase]}>{step.phase}</Badge>
+                  <span className="text-sm text-white">{step.label}</span>
+                </div>
+                <div className="flex items-center gap-2 text-xs text-dark-500">
+                  {step.toolCalls.length > 0 && (
+                    <span>{step.toolCalls.length} tool</span>
+                  )}
+                  {step.memoryOps.length > 0 && (
+                    <span>{step.memoryOps.length} mem</span>
+                  )}
+                  <span>{open ? "−" : "+"}</span>
+                </div>
+              </button>
+
+              {open && (
+                <div className="space-y-4 border-t border-dark-700 px-5 py-4">
+                  {step.context && (
+                    <Section title="Assembled context">
+                      <pre className="max-h-72 overflow-auto whitespace-pre-wrap rounded-lg bg-dark-900/70 p-3 text-xs text-dark-300">
+                        {step.context}
+                      </pre>
+                    </Section>
+                  )}
+
+                  {step.selectedTools && step.selectedTools.length > 0 && (
+                    <Section title="Selected tools">
+                      <div className="flex flex-wrap gap-2">
+                        {step.selectedTools.map((tool) => (
+                          <span
+                            key={tool}
+                            className="rounded-md bg-dark-700 px-2 py-1 font-mono text-xs text-dark-300"
+                          >
+                            {tool}
+                          </span>
+                        ))}
+                      </div>
+                    </Section>
+                  )}
+
+                  {step.toolCalls.map((call, i) => (
+                    <Section key={i} title={`Tool call — ${call.name}`}>
+                      {call.durationMs != null && (
+                        <p className="mb-2 text-xs text-dark-500">{call.durationMs} ms</p>
+                      )}
+                      <div className="grid gap-3 md:grid-cols-2">
+                        <div>
+                          <p className="mb-1 text-xs font-medium text-dark-400">Args</p>
+                          <pre className="max-h-60 overflow-auto rounded-lg bg-dark-900/70 p-3 text-xs text-dark-300">
+                            {formatValue(call.args) || "—"}
+                          </pre>
+                        </div>
+                        <div>
+                          <p className="mb-1 text-xs font-medium text-dark-400">
+                            {call.error ? "Error" : "Result"}
+                          </p>
+                          <pre
+                            className={cn(
+                              "max-h-60 overflow-auto rounded-lg bg-dark-900/70 p-3 text-xs",
+                              call.error ? "text-danger-400" : "text-dark-300",
+                            )}
+                          >
+                            {call.error ?? (formatValue(call.result) || "—")}
+                          </pre>
+                        </div>
+                      </div>
+                    </Section>
+                  ))}
+
+                  {step.memoryOps.length > 0 && (
+                    <Section title="Memory operations">
+                      <ul className="space-y-1">
+                        {step.memoryOps.map((mem, i) => (
+                          <li
+                            key={i}
+                            className="flex items-center gap-2 text-xs text-dark-400"
+                          >
+                            <Badge variant="success">{mem.op}</Badge>
+                            {mem.tier && <span className="text-dark-500">{mem.tier}</span>}
+                            {mem.content && (
+                              <span className="font-mono text-dark-300">{mem.content}</span>
+                            )}
+                          </li>
+                        ))}
+                      </ul>
+                    </Section>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function FilterChip({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        "rounded-full px-3 py-1 text-xs transition-colors",
+        active
+          ? "bg-accent-600/20 text-accent-400"
+          : "bg-dark-800 text-dark-400 hover:bg-dark-700 hover:text-white",
+      )}
+    >
+      {label}
+    </button>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-dark-500">
+        {title}
+      </h3>
+      {children}
+    </div>
+  );
+}

--- a/apps/web/components/RunTimeline.tsx
+++ b/apps/web/components/RunTimeline.tsx
@@ -4,75 +4,18 @@ import { useMemo } from "react";
 import { Activity, CheckCircle2, Coins, XCircle } from "lucide-react";
 import { Badge } from "@/components/Badge";
 import { cn, formatCost, formatTokens } from "@/lib/utils";
+import {
+  currentPhase,
+  kindColor,
+  sortRuns,
+  type AgentRun,
+  type RunSpan,
+  type RunSpanKind,
+} from "@/components/run-timeline";
 
-export type RunSpanKind =
-  | "context"
-  | "model"
-  | "tool"
-  | "memory"
-  | "skill"
-  | "handoff"
-  | "custom";
-
-export interface RunSpan {
-  spanId: string;
-  name: string;
-  kind: RunSpanKind;
-  startedAt: number;
-  endedAt?: number;
-  durationMs?: number;
-  status: "ok" | "error" | "cancelled";
-}
-
-export interface AgentRun {
-  traceId: string;
-  sessionId: string;
-  agentId: string;
-  startedAt: number;
-  endedAt?: number;
-  durationMs?: number;
-  model: string;
-  inputTokens: number;
-  outputTokens: number;
-  costUsd: number;
-  toolCalls: number;
-  success: boolean;
-  error?: string;
-  spans: RunSpan[];
-}
-
-const kindColor: Record<RunSpanKind, string> = {
-  context: "bg-blue-500/60",
-  model: "bg-purple-500/60",
-  tool: "bg-green-500/60",
-  memory: "bg-amber-500/60",
-  skill: "bg-cyan-500/60",
-  handoff: "bg-pink-500/60",
-  custom: "bg-dark-500/60",
-};
-
-/**
- * Derive the human-readable current "phase" for a run from its spans.
- * For an active run the phase is the kind of the last still-open span (or the
- * most recent span). For a finished run we report a terminal phase.
- */
-export function currentPhase(run: AgentRun): { label: string; tool?: string; kind?: RunSpanKind } {
-  if (run.endedAt !== undefined) {
-    return { label: run.success ? "completed" : "failed" };
-  }
-  const openSpan = [...run.spans]
-    .reverse()
-    .find((span) => span.endedAt === undefined);
-  const span = openSpan ?? run.spans[run.spans.length - 1];
-  if (!span) {
-    return { label: "starting" };
-  }
-  return {
-    label: span.kind,
-    tool: span.kind === "tool" ? span.name : undefined,
-    kind: span.kind,
-  };
-}
+// Re-export the pure logic/types so existing importers of this component keep working.
+export { currentPhase, sortRuns };
+export type { AgentRun, RunSpan, RunSpanKind };
 
 export function RunTimeline({
   runs,
@@ -81,17 +24,7 @@ export function RunTimeline({
   runs: AgentRun[];
   className?: string;
 }) {
-  const sorted = useMemo(
-    () =>
-      [...runs].sort((a, b) => {
-        // Active runs first, then by most recent start.
-        const aActive = a.endedAt === undefined ? 1 : 0;
-        const bActive = b.endedAt === undefined ? 1 : 0;
-        if (aActive !== bActive) return bActive - aActive;
-        return b.startedAt - a.startedAt;
-      }),
-    [runs],
-  );
+  const sorted = useMemo(() => sortRuns(runs), [runs]);
 
   if (sorted.length === 0) {
     return (

--- a/apps/web/components/RunTimeline.tsx
+++ b/apps/web/components/RunTimeline.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import { useMemo } from "react";
+import { Activity, CheckCircle2, Coins, XCircle } from "lucide-react";
+import { Badge } from "@/components/Badge";
+import { cn, formatCost, formatTokens } from "@/lib/utils";
+
+export type RunSpanKind =
+  | "context"
+  | "model"
+  | "tool"
+  | "memory"
+  | "skill"
+  | "handoff"
+  | "custom";
+
+export interface RunSpan {
+  spanId: string;
+  name: string;
+  kind: RunSpanKind;
+  startedAt: number;
+  endedAt?: number;
+  durationMs?: number;
+  status: "ok" | "error" | "cancelled";
+}
+
+export interface AgentRun {
+  traceId: string;
+  sessionId: string;
+  agentId: string;
+  startedAt: number;
+  endedAt?: number;
+  durationMs?: number;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+  toolCalls: number;
+  success: boolean;
+  error?: string;
+  spans: RunSpan[];
+}
+
+const kindColor: Record<RunSpanKind, string> = {
+  context: "bg-blue-500/60",
+  model: "bg-purple-500/60",
+  tool: "bg-green-500/60",
+  memory: "bg-amber-500/60",
+  skill: "bg-cyan-500/60",
+  handoff: "bg-pink-500/60",
+  custom: "bg-dark-500/60",
+};
+
+/**
+ * Derive the human-readable current "phase" for a run from its spans.
+ * For an active run the phase is the kind of the last still-open span (or the
+ * most recent span). For a finished run we report a terminal phase.
+ */
+export function currentPhase(run: AgentRun): { label: string; tool?: string; kind?: RunSpanKind } {
+  if (run.endedAt !== undefined) {
+    return { label: run.success ? "completed" : "failed" };
+  }
+  const openSpan = [...run.spans]
+    .reverse()
+    .find((span) => span.endedAt === undefined);
+  const span = openSpan ?? run.spans[run.spans.length - 1];
+  if (!span) {
+    return { label: "starting" };
+  }
+  return {
+    label: span.kind,
+    tool: span.kind === "tool" ? span.name : undefined,
+    kind: span.kind,
+  };
+}
+
+export function RunTimeline({
+  runs,
+  className,
+}: {
+  runs: AgentRun[];
+  className?: string;
+}) {
+  const sorted = useMemo(
+    () =>
+      [...runs].sort((a, b) => {
+        // Active runs first, then by most recent start.
+        const aActive = a.endedAt === undefined ? 1 : 0;
+        const bActive = b.endedAt === undefined ? 1 : 0;
+        if (aActive !== bActive) return bActive - aActive;
+        return b.startedAt - a.startedAt;
+      }),
+    [runs],
+  );
+
+  if (sorted.length === 0) {
+    return (
+      <div
+        className={cn(
+          "rounded-xl border border-dark-700 bg-dark-800 px-5 py-12 text-center text-sm text-dark-400",
+          className,
+        )}
+      >
+        No agent runs are active right now.
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("space-y-3", className)}>
+      {sorted.map((run) => {
+        const isActive = run.endedAt === undefined;
+        const phase = currentPhase(run);
+        const totalDuration = Math.max(
+          run.durationMs ?? Date.now() - run.startedAt,
+          1,
+        );
+
+        return (
+          <div
+            key={run.traceId}
+            className={cn(
+              "rounded-xl border p-4",
+              isActive ? "border-accent-500/60 bg-accent-600/5" : "border-dark-700 bg-dark-800",
+            )}
+          >
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div className="space-y-1 min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                  {isActive ? (
+                    <Badge variant="info">
+                      <span className="inline-flex items-center gap-1.5">
+                        <span className="relative flex h-2 w-2">
+                          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-blue-400 opacity-75" />
+                          <span className="relative inline-flex h-2 w-2 rounded-full bg-blue-400" />
+                        </span>
+                        running
+                      </span>
+                    </Badge>
+                  ) : run.success ? (
+                    <Badge variant="success">
+                      <span className="inline-flex items-center gap-1">
+                        <CheckCircle2 size={12} /> done
+                      </span>
+                    </Badge>
+                  ) : (
+                    <Badge variant="danger">
+                      <span className="inline-flex items-center gap-1">
+                        <XCircle size={12} /> error
+                      </span>
+                    </Badge>
+                  )}
+                  <span className="text-sm font-medium text-white truncate">
+                    {run.agentId}
+                  </span>
+                  <span className="text-xs text-dark-500">{run.model || "unknown model"}</span>
+                </div>
+                <div className="flex flex-wrap items-center gap-3 text-xs text-dark-400">
+                  <span className="inline-flex items-center gap-1">
+                    <Activity size={12} />
+                    phase:{" "}
+                    <span className="text-dark-200 font-medium">
+                      {phase.tool ? `tool · ${phase.tool}` : phase.label}
+                    </span>
+                  </span>
+                  <span>session {run.sessionId}</span>
+                  <span>{run.toolCalls} tools</span>
+                </div>
+              </div>
+
+              <div className="text-right text-xs text-dark-400 shrink-0 space-y-1">
+                <p className="inline-flex items-center gap-1 text-dark-200">
+                  <Coins size={12} /> {formatCost(run.costUsd)}
+                </p>
+                <p>{formatTokens(run.inputTokens + run.outputTokens)} tokens</p>
+                <p>{Math.round(totalDuration)}ms</p>
+              </div>
+            </div>
+
+            {/* Span timeline bar */}
+            <div className="mt-3 h-6 relative overflow-hidden rounded bg-dark-900">
+              {run.spans.map((span) => {
+                const offset = ((span.startedAt - run.startedAt) / totalDuration) * 100;
+                const spanDuration =
+                  span.durationMs ??
+                  (span.endedAt !== undefined
+                    ? span.endedAt - span.startedAt
+                    : Date.now() - span.startedAt);
+                const width = Math.max(2, (Math.max(spanDuration, 1) / totalDuration) * 100);
+                const isOpen = span.endedAt === undefined;
+                return (
+                  <div
+                    key={span.spanId}
+                    className={cn(
+                      "absolute top-1 h-4 rounded-sm",
+                      span.status === "error" ? "bg-red-500/60" : kindColor[span.kind],
+                      isOpen && "animate-pulse",
+                    )}
+                    style={{
+                      left: `${Math.min(Math.max(offset, 0), 100)}%`,
+                      width: `${Math.min(width, 100)}%`,
+                    }}
+                    title={`${span.kind}: ${span.name} (${Math.round(spanDuration)}ms)${isOpen ? " — running" : ""}`}
+                  />
+                );
+              })}
+            </div>
+
+            {run.error && (
+              <p className="mt-2 text-xs text-red-300 break-words">{run.error}</p>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/components/Sidebar.tsx
+++ b/apps/web/components/Sidebar.tsx
@@ -28,6 +28,8 @@ import {
   CreditCard,
   KeyRound,
   UserCircle,
+  Coins,
+  ClipboardCheck,
 } from "lucide-react";
 import { useState, useEffect } from "react";
 import { cn } from "@/lib/utils";
@@ -58,6 +60,9 @@ export const navGroups: NavGroup[] = [
           { label: "Overview", href: "/dashboard", icon: <BarChart3 size={16} /> },
           { label: "Sessions", href: "/dashboard/sessions", icon: <History size={16} /> },
           { label: "Analytics", href: "/dashboard/analytics", icon: <BarChart3 size={16} /> },
+          { label: "Usage", href: "/dashboard/usage", icon: <Coins size={16} /> },
+          { label: "Evals", href: "/dashboard/evals", icon: <ClipboardCheck size={16} /> },
+          { label: "Timeline", href: "/dashboard/timeline", icon: <Activity size={16} /> },
         ],
       },
       { label: "Workflows", href: "/workflows", icon: <GitBranch size={18} /> },

--- a/apps/web/components/approvals.ts
+++ b/apps/web/components/approvals.ts
@@ -1,0 +1,86 @@
+// apps/web/components/approvals.ts
+// Pure helpers for the human-approval-checkpoints UI. Kept framework-free so
+// they can be unit-tested without a DOM.
+
+export type RiskLevel = 'low' | 'medium' | 'high' | 'critical';
+
+export interface PendingApproval {
+  id: string;
+  toolName: string;
+  riskLevel: RiskLevel;
+  args: Record<string, unknown>;
+  sessionId?: string;
+  requestedAt?: string;
+  reason?: string;
+  status?: 'pending' | 'approved' | 'denied';
+}
+
+export type BadgeVariant = 'default' | 'success' | 'warning' | 'danger' | 'info';
+
+const riskVariant: Record<RiskLevel, BadgeVariant> = {
+  low: 'success',
+  medium: 'info',
+  high: 'warning',
+  critical: 'danger',
+};
+
+export function riskBadgeVariant(level: RiskLevel | undefined): BadgeVariant {
+  if (!level) return 'default';
+  return riskVariant[level] ?? 'default';
+}
+
+/** Normalize a raw gateway payload into a typed list of pending approvals. */
+export function normalizeApprovals(data: unknown): PendingApproval[] {
+  const raw = Array.isArray(data)
+    ? data
+    : ((data as { approvals?: unknown[] })?.approvals ??
+      (data as { pending?: unknown[] })?.pending ??
+      []);
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .filter((r): r is Record<string, unknown> => !!r && typeof r === 'object')
+    .map((r) => ({
+      id: String(r.id ?? ''),
+      toolName: String(r.toolName ?? r.tool ?? r.name ?? 'unknown'),
+      riskLevel: (r.riskLevel ?? r.risk ?? 'high') as RiskLevel,
+      args:
+        r.args && typeof r.args === 'object'
+          ? (r.args as Record<string, unknown>)
+          : {},
+      sessionId: r.sessionId ? String(r.sessionId) : undefined,
+      requestedAt: r.requestedAt ? String(r.requestedAt) : undefined,
+      reason: r.reason ? String(r.reason) : undefined,
+      status: (r.status as PendingApproval['status']) ?? 'pending',
+    }))
+    .filter((a) => a.id);
+}
+
+/** Pretty-print args JSON, falling back to a string on cyclic/invalid input. */
+export function formatArgs(args: unknown): string {
+  try {
+    return JSON.stringify(args ?? {}, null, 2);
+  } catch {
+    return String(args);
+  }
+}
+
+/**
+ * Parse edited args text back into an object.
+ * Returns { ok, value } or { ok:false, error } so the UI can show a message
+ * without throwing.
+ */
+export function parseEditedArgs(
+  text: string,
+): { ok: true; value: Record<string, unknown> } | { ok: false; error: string } {
+  const trimmed = text.trim();
+  if (!trimmed) return { ok: true, value: {} };
+  try {
+    const parsed = JSON.parse(trimmed);
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return { ok: false, error: 'Arguments must be a JSON object.' };
+    }
+    return { ok: true, value: parsed as Record<string, unknown> };
+  } catch (e) {
+    return { ok: false, error: `Invalid JSON: ${(e as Error).message}` };
+  }
+}

--- a/apps/web/components/run-timeline.ts
+++ b/apps/web/components/run-timeline.ts
@@ -1,0 +1,82 @@
+// Pure, framework-free logic for the run timeline (#583).
+//
+// Kept in a `.ts` (not `.tsx`) module so it can be unit-tested under Vitest's
+// node environment, which has no JSX transform — mirrors the approvals.ts /
+// runTrace.ts split. RunTimeline.tsx re-exports these and adds the React view.
+
+export type RunSpanKind =
+  | "context"
+  | "model"
+  | "tool"
+  | "memory"
+  | "skill"
+  | "handoff"
+  | "custom";
+
+export interface RunSpan {
+  spanId: string;
+  name: string;
+  kind: RunSpanKind;
+  startedAt: number;
+  endedAt?: number;
+  durationMs?: number;
+  status: "ok" | "error" | "cancelled";
+}
+
+export interface AgentRun {
+  traceId: string;
+  sessionId: string;
+  agentId: string;
+  startedAt: number;
+  endedAt?: number;
+  durationMs?: number;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+  toolCalls: number;
+  success: boolean;
+  error?: string;
+  spans: RunSpan[];
+}
+
+export const kindColor: Record<RunSpanKind, string> = {
+  context: "bg-blue-500/60",
+  model: "bg-purple-500/60",
+  tool: "bg-green-500/60",
+  memory: "bg-amber-500/60",
+  skill: "bg-cyan-500/60",
+  handoff: "bg-pink-500/60",
+  custom: "bg-dark-500/60",
+};
+
+/**
+ * Derive the human-readable current "phase" for a run from its spans.
+ * For an active run the phase is the kind of the last still-open span (or the
+ * most recent span). For a finished run we report a terminal phase.
+ */
+export function currentPhase(run: AgentRun): { label: string; tool?: string; kind?: RunSpanKind } {
+  if (run.endedAt !== undefined) {
+    return { label: run.success ? "completed" : "failed" };
+  }
+  const openSpan = [...run.spans].reverse().find((span) => span.endedAt === undefined);
+  const span = openSpan ?? run.spans[run.spans.length - 1];
+  if (!span) {
+    return { label: "starting" };
+  }
+  return {
+    label: span.kind,
+    tool: span.kind === "tool" ? span.name : undefined,
+    kind: span.kind,
+  };
+}
+
+/** Sort runs for display: active runs first, then most recently started. */
+export function sortRuns(runs: AgentRun[]): AgentRun[] {
+  return [...runs].sort((a, b) => {
+    const aActive = a.endedAt === undefined ? 1 : 0;
+    const bActive = b.endedAt === undefined ? 1 : 0;
+    if (aActive !== bActive) return bActive - aActive;
+    return b.startedAt - a.startedAt;
+  });
+}

--- a/apps/web/components/runTrace.ts
+++ b/apps/web/components/runTrace.ts
@@ -1,0 +1,174 @@
+// apps/web/components/runTrace.ts
+// Pure helpers for the run-debugger panel. Framework-free + unit-testable.
+
+export type StepPhase =
+  | 'context'
+  | 'tool-selection'
+  | 'model'
+  | 'tool-call'
+  | 'memory'
+  | 'response'
+  | 'other';
+
+export interface ToolCallTrace {
+  name: string;
+  args?: unknown;
+  result?: unknown;
+  error?: string;
+  durationMs?: number;
+}
+
+export interface MemoryOp {
+  op: string;
+  tier?: string;
+  content?: string;
+}
+
+export interface RunStep {
+  index: number;
+  phase: StepPhase;
+  label: string;
+  context?: string;
+  selectedTools?: string[];
+  toolCalls: ToolCallTrace[];
+  memoryOps: MemoryOp[];
+  raw: Record<string, unknown>;
+}
+
+const KNOWN_PHASES: StepPhase[] = [
+  'context',
+  'tool-selection',
+  'model',
+  'tool-call',
+  'memory',
+  'response',
+  'other',
+];
+
+function coercePhase(value: unknown): StepPhase {
+  const s = String(value ?? '').toLowerCase();
+  if ((KNOWN_PHASES as string[]).includes(s)) return s as StepPhase;
+  if (s.includes('context')) return 'context';
+  if (s.includes('select')) return 'tool-selection';
+  if (s.includes('model') || s.includes('llm')) return 'model';
+  if (s.includes('tool')) return 'tool-call';
+  if (s.includes('memory') || s.includes('mem')) return 'memory';
+  if (s.includes('response') || s.includes('stream')) return 'response';
+  return 'other';
+}
+
+function toToolCalls(raw: Record<string, unknown>): ToolCallTrace[] {
+  const calls: ToolCallTrace[] = [];
+  const candidates =
+    (raw.toolCalls as unknown[]) ??
+    (raw.tools as unknown[]) ??
+    (raw.tool ? [raw.tool] : []);
+  if (Array.isArray(candidates)) {
+    for (const c of candidates) {
+      if (c && typeof c === 'object') {
+        const o = c as Record<string, unknown>;
+        calls.push({
+          name: String(o.name ?? o.tool ?? 'tool'),
+          args: o.args ?? o.input,
+          result: o.result ?? o.output,
+          error: o.error ? String(o.error) : undefined,
+          durationMs: typeof o.durationMs === 'number' ? o.durationMs : undefined,
+        });
+      }
+    }
+  }
+  // Single inline tool call shape: { toolName, args, result }
+  if (raw.toolName) {
+    calls.push({
+      name: String(raw.toolName),
+      args: raw.args ?? raw.input,
+      result: raw.result ?? raw.output,
+      error: raw.error ? String(raw.error) : undefined,
+      durationMs: typeof raw.durationMs === 'number' ? raw.durationMs : undefined,
+    });
+  }
+  return calls;
+}
+
+function toMemoryOps(raw: Record<string, unknown>): MemoryOp[] {
+  const ops: MemoryOp[] = [];
+  const candidates = (raw.memoryOps as unknown[]) ?? (raw.memory as unknown[]) ?? [];
+  if (Array.isArray(candidates)) {
+    for (const c of candidates) {
+      if (c && typeof c === 'object') {
+        const o = c as Record<string, unknown>;
+        ops.push({
+          op: String(o.op ?? o.operation ?? o.type ?? 'op'),
+          tier: o.tier ? String(o.tier) : undefined,
+          content: o.content ? String(o.content) : undefined,
+        });
+      } else if (typeof c === 'string') {
+        ops.push({ op: c });
+      }
+    }
+  }
+  return ops;
+}
+
+function toStringMaybe(value: unknown): string | undefined {
+  if (value == null) return undefined;
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+/** Normalize replay/trace payloads into a typed list of run steps. */
+export function normalizeSteps(data: unknown): RunStep[] {
+  const raw =
+    (data as { steps?: unknown[] })?.steps ??
+    (data as { trace?: unknown[] })?.trace ??
+    (data as { traces?: unknown[] })?.traces ??
+    (Array.isArray(data) ? data : []);
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .filter((s): s is Record<string, unknown> => !!s && typeof s === 'object')
+    .map((s, i) => {
+      const selected =
+        (s.selectedTools as unknown[]) ?? (s.tools as unknown[]) ?? undefined;
+      return {
+        index: typeof s.index === 'number' ? s.index : i,
+        phase: coercePhase(s.phase ?? s.type ?? s.kind),
+        label: String(s.label ?? s.name ?? s.phase ?? s.type ?? `Step ${i + 1}`),
+        context: toStringMaybe(s.context ?? s.prompt ?? s.systemPrompt),
+        selectedTools: Array.isArray(selected)
+          ? selected.map((t) =>
+              typeof t === 'string'
+                ? t
+                : String((t as Record<string, unknown>)?.name ?? t),
+            )
+          : undefined,
+        toolCalls: toToolCalls(s),
+        memoryOps: toMemoryOps(s),
+        raw: s,
+      };
+    });
+}
+
+/** Distinct phases present in a set of steps, in canonical order. */
+export function phasesPresent(steps: RunStep[]): StepPhase[] {
+  const present = new Set(steps.map((s) => s.phase));
+  return KNOWN_PHASES.filter((p) => present.has(p));
+}
+
+export function filterByPhase(steps: RunStep[], phase: StepPhase | 'all'): RunStep[] {
+  if (phase === 'all') return steps;
+  return steps.filter((s) => s.phase === phase);
+}
+
+export function formatValue(value: unknown): string {
+  if (value == null) return '';
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}

--- a/tests/mobile/gateway-client.test.ts
+++ b/tests/mobile/gateway-client.test.ts
@@ -44,6 +44,23 @@ vi.mock("expo-av", () => ({
   },
 }));
 
+vi.mock("expo-notifications", () => ({
+  setNotificationHandler: vi.fn(),
+  scheduleNotificationAsync: vi.fn().mockResolvedValue("notif-id"),
+  cancelScheduledNotificationAsync: vi.fn().mockResolvedValue(undefined),
+  cancelAllScheduledNotificationsAsync: vi.fn().mockResolvedValue(undefined),
+  getPermissionsAsync: vi.fn(),
+  requestPermissionsAsync: vi.fn(),
+  getExpoPushTokenAsync: vi.fn(),
+  addNotificationReceivedListener: vi.fn(),
+  addNotificationResponseReceivedListener: vi.fn(),
+  setNotificationChannelAsync: vi.fn(),
+  AndroidImportance: { HIGH: 4 },
+  SchedulableTriggerInputTypes: { TIME_INTERVAL: "timeInterval" },
+}));
+
+vi.mock("react-native", () => ({ Platform: { OS: "ios" } }));
+
 type TestGatewayClient = {
   handleProtocolMessage: (message: {
     type: string;

--- a/tests/mobile/notifications-dispatch.test.ts
+++ b/tests/mobile/notifications-dispatch.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// expo-notifications and react-native are native-only; mock them so the module
+// imports cleanly under Node. The actual dispatch logic is exercised through an
+// injected fake backend, so these mocks only need to exist.
+vi.mock("expo-notifications", () => ({
+  setNotificationHandler: vi.fn(),
+  getPermissionsAsync: vi.fn(),
+  requestPermissionsAsync: vi.fn(),
+  getExpoPushTokenAsync: vi.fn(),
+  scheduleNotificationAsync: vi.fn(),
+  cancelScheduledNotificationAsync: vi.fn(),
+  cancelAllScheduledNotificationsAsync: vi.fn(),
+  addNotificationReceivedListener: vi.fn(),
+  addNotificationResponseReceivedListener: vi.fn(),
+  setNotificationChannelAsync: vi.fn(),
+  AndroidImportance: { HIGH: 4 },
+  SchedulableTriggerInputTypes: { TIME_INTERVAL: "timeInterval" },
+}));
+
+vi.mock("react-native", () => ({
+  Platform: { OS: "ios" },
+}));
+
+import {
+  notifyApprovalNeeded,
+  notifyRunComplete,
+  shouldNotify,
+  cancelKarnaNotification,
+  setNotificationBackend,
+  type KarnaNotificationData,
+  type KarnaNotificationPreferences,
+  type NotificationBackend,
+} from "../../../karna/apps/mobile/lib/notifications";
+
+const allEnabled: KarnaNotificationPreferences = {
+  enabled: true,
+  approvalsEnabled: true,
+  runCompletionEnabled: true,
+};
+
+interface Dispatched {
+  title: string;
+  body: string;
+  data: KarnaNotificationData;
+}
+
+function makeFakeBackend() {
+  const scheduled: Dispatched[] = [];
+  const cancelled: string[] = [];
+  let counter = 0;
+  const backend: NotificationBackend = {
+    async scheduleImmediate(title, body, data) {
+      scheduled.push({ title, body, data });
+      return `notif-${++counter}`;
+    },
+    async cancel(id) {
+      cancelled.push(id);
+    },
+  };
+  return { backend, scheduled, cancelled };
+}
+
+describe("notification dispatch (issue #612)", () => {
+  let fake: ReturnType<typeof makeFakeBackend>;
+
+  beforeEach(() => {
+    fake = makeFakeBackend();
+    setNotificationBackend(fake.backend);
+  });
+
+  afterEach(() => {
+    setNotificationBackend();
+  });
+
+  it("dispatches an approval-needed notification deep-linking to tasks", async () => {
+    const id = await notifyApprovalNeeded(
+      { toolName: "shell.exec", toolCallId: "tc-1", riskLevel: "high" },
+      allEnabled,
+    );
+
+    expect(id).toBe("notif-1");
+    expect(fake.scheduled).toHaveLength(1);
+    const [n] = fake.scheduled;
+    expect(n.title).toBe("Approval needed");
+    expect(n.body).toContain("shell.exec");
+    expect(n.body).toContain("high");
+    expect(n.data.kind).toBe("approval-needed");
+    expect(n.data.tab).toBe("tasks");
+    expect(n.data.toolCallId).toBe("tc-1");
+  });
+
+  it("dispatches a run-complete notification deep-linking to tasks", async () => {
+    const id = await notifyRunComplete(
+      { title: "Nightly report", runId: "run-9", success: true },
+      allEnabled,
+    );
+
+    expect(id).toBe("notif-1");
+    const [n] = fake.scheduled;
+    expect(n.title).toBe("Task complete");
+    expect(n.body).toContain("Nightly report");
+    expect(n.body).toContain("completed");
+    expect(n.data.kind).toBe("run-complete");
+    expect(n.data.tab).toBe("tasks");
+    expect(n.data.runId).toBe("run-9");
+  });
+
+  it("marks failed runs in the body", async () => {
+    await notifyRunComplete(
+      { title: "Backup", success: false },
+      allEnabled,
+    );
+    expect(fake.scheduled[0].body).toContain("finished with errors");
+  });
+
+  it("suppresses notifications when master switch is off", async () => {
+    const prefs: KarnaNotificationPreferences = {
+      ...allEnabled,
+      enabled: false,
+    };
+    expect(await notifyApprovalNeeded({ toolName: "x", toolCallId: "1" }, prefs)).toBeNull();
+    expect(await notifyRunComplete({ title: "y" }, prefs)).toBeNull();
+    expect(fake.scheduled).toHaveLength(0);
+  });
+
+  it("respects per-kind opt-out", async () => {
+    const noApprovals: KarnaNotificationPreferences = {
+      enabled: true,
+      approvalsEnabled: false,
+      runCompletionEnabled: true,
+    };
+    expect(
+      await notifyApprovalNeeded({ toolName: "x", toolCallId: "1" }, noApprovals),
+    ).toBeNull();
+    // run-complete still fires
+    expect(await notifyRunComplete({ title: "y" }, noApprovals)).toBe("notif-1");
+    expect(fake.scheduled).toHaveLength(1);
+  });
+
+  it("shouldNotify encodes the preference policy", () => {
+    expect(shouldNotify("approval-needed", allEnabled)).toBe(true);
+    expect(shouldNotify("run-complete", allEnabled)).toBe(true);
+    expect(
+      shouldNotify("approval-needed", { ...allEnabled, approvalsEnabled: false }),
+    ).toBe(false);
+    expect(
+      shouldNotify("run-complete", { ...allEnabled, runCompletionEnabled: false }),
+    ).toBe(false);
+    expect(shouldNotify("approval-needed", { ...allEnabled, enabled: false })).toBe(
+      false,
+    );
+  });
+
+  it("cancels through the injected backend", async () => {
+    const id = await notifyApprovalNeeded(
+      { toolName: "x", toolCallId: "1" },
+      allEnabled,
+    );
+    expect(id).not.toBeNull();
+    await cancelKarnaNotification(id as string);
+    expect(fake.cancelled).toEqual([id]);
+  });
+});

--- a/tests/mobile/notifications-routing.test.ts
+++ b/tests/mobile/notifications-routing.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("expo-notifications", () => ({
+  setNotificationHandler: vi.fn(),
+  getPermissionsAsync: vi.fn(),
+  requestPermissionsAsync: vi.fn(),
+  getExpoPushTokenAsync: vi.fn(),
+  scheduleNotificationAsync: vi.fn(),
+  cancelScheduledNotificationAsync: vi.fn(),
+  cancelAllScheduledNotificationsAsync: vi.fn(),
+  addNotificationReceivedListener: vi.fn(),
+  addNotificationResponseReceivedListener: vi.fn(),
+  setNotificationChannelAsync: vi.fn(),
+  AndroidImportance: { HIGH: 4 },
+  SchedulableTriggerInputTypes: { TIME_INTERVAL: "timeInterval" },
+}));
+
+vi.mock("react-native", () => ({
+  Platform: { OS: "ios" },
+}));
+
+import {
+  parseKarnaNotificationData,
+  notificationTabForKind,
+} from "../../../karna/apps/mobile/lib/notifications";
+import { getMobileTabRoute } from "../../../karna/apps/mobile/lib/deep-links";
+
+describe("notification response routing (issue #612)", () => {
+  it("parses approval-needed payloads and routes to the tasks tab", () => {
+    const data = parseKarnaNotificationData({
+      kind: "approval-needed",
+      tab: "tasks",
+      toolCallId: "tc-1",
+    });
+    expect(data).not.toBeNull();
+    expect(data?.kind).toBe("approval-needed");
+    expect(data?.toolCallId).toBe("tc-1");
+    expect(getMobileTabRoute(data?.tab)).toBe("/(tabs)/tasks");
+  });
+
+  it("parses run-complete payloads and routes to the tasks tab", () => {
+    const data = parseKarnaNotificationData({
+      kind: "run-complete",
+      tab: "tasks",
+      runId: "run-7",
+    });
+    expect(data?.kind).toBe("run-complete");
+    expect(data?.runId).toBe("run-7");
+    expect(getMobileTabRoute(data?.tab)).toBe("/(tabs)/tasks");
+  });
+
+  it("falls back to the kind's default tab when tab is missing", () => {
+    const data = parseKarnaNotificationData({ kind: "approval-needed" });
+    expect(data?.tab).toBe(notificationTabForKind("approval-needed"));
+    expect(getMobileTabRoute(data?.tab)).toBe("/(tabs)/tasks");
+  });
+
+  it("returns null for non-Karna payloads", () => {
+    expect(parseKarnaNotificationData(undefined)).toBeNull();
+    expect(parseKarnaNotificationData(null)).toBeNull();
+    expect(parseKarnaNotificationData({ tab: "chat" })).toBeNull();
+    expect(parseKarnaNotificationData({ kind: "other" })).toBeNull();
+    expect(parseKarnaNotificationData("string")).toBeNull();
+  });
+
+  it("ignores non-string id fields defensively", () => {
+    const data = parseKarnaNotificationData({
+      kind: "run-complete",
+      tab: "tasks",
+      runId: 123,
+    });
+    expect(data?.runId).toBeUndefined();
+  });
+});

--- a/tests/web/approvals.test.ts
+++ b/tests/web/approvals.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeApprovals,
+  formatArgs,
+  parseEditedArgs,
+  riskBadgeVariant,
+} from '../../apps/web/components/approvals';
+
+describe('normalizeApprovals', () => {
+  it('handles array payloads', () => {
+    const out = normalizeApprovals([
+      { id: 'a1', toolName: 'shell', riskLevel: 'high', args: { cmd: 'ls' } },
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].toolName).toBe('shell');
+    expect(out[0].args).toEqual({ cmd: 'ls' });
+    expect(out[0].status).toBe('pending');
+  });
+
+  it('handles wrapped { approvals } and { pending } payloads', () => {
+    expect(normalizeApprovals({ approvals: [{ id: 'x' }] })).toHaveLength(1);
+    expect(normalizeApprovals({ pending: [{ id: 'y' }] })).toHaveLength(1);
+  });
+
+  it('maps alternate field names and defaults risk to high', () => {
+    const out = normalizeApprovals([{ id: 'z', tool: 'http' }]);
+    expect(out[0].toolName).toBe('http');
+    expect(out[0].riskLevel).toBe('high');
+  });
+
+  it('drops entries without an id and ignores junk', () => {
+    expect(normalizeApprovals([{ toolName: 'x' }, null, 'str'])).toHaveLength(0);
+    expect(normalizeApprovals(undefined)).toEqual([]);
+  });
+});
+
+describe('formatArgs', () => {
+  it('pretty-prints objects', () => {
+    expect(formatArgs({ a: 1 })).toContain('"a": 1');
+  });
+  it('handles cyclic input gracefully', () => {
+    const o: Record<string, unknown> = {};
+    o.self = o;
+    expect(typeof formatArgs(o)).toBe('string');
+  });
+});
+
+describe('parseEditedArgs', () => {
+  it('parses a JSON object', () => {
+    const r = parseEditedArgs('{"x": 2}');
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value).toEqual({ x: 2 });
+  });
+  it('treats empty input as empty object', () => {
+    const r = parseEditedArgs('   ');
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value).toEqual({});
+  });
+  it('rejects arrays and primitives', () => {
+    expect(parseEditedArgs('[1,2]').ok).toBe(false);
+    expect(parseEditedArgs('42').ok).toBe(false);
+  });
+  it('rejects invalid JSON', () => {
+    expect(parseEditedArgs('{bad').ok).toBe(false);
+  });
+});
+
+describe('riskBadgeVariant', () => {
+  it('maps known levels', () => {
+    expect(riskBadgeVariant('low')).toBe('success');
+    expect(riskBadgeVariant('critical')).toBe('danger');
+  });
+  it('falls back to default', () => {
+    expect(riskBadgeVariant(undefined)).toBe('default');
+  });
+});

--- a/tests/web/run-timeline.test.ts
+++ b/tests/web/run-timeline.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { currentPhase, type AgentRun } from "../../apps/web/components/RunTimeline";
+
+function makeRun(overrides: Partial<AgentRun>): AgentRun {
+  return {
+    traceId: "t1",
+    sessionId: "s1",
+    agentId: "agent",
+    startedAt: 1000,
+    model: "claude",
+    inputTokens: 0,
+    outputTokens: 0,
+    costUsd: 0,
+    toolCalls: 0,
+    success: true,
+    spans: [],
+    ...overrides,
+  };
+}
+
+describe("currentPhase", () => {
+  it("reports completed for a finished successful run", () => {
+    const run = makeRun({ endedAt: 2000, success: true });
+    expect(currentPhase(run).label).toBe("completed");
+  });
+
+  it("reports failed for a finished unsuccessful run", () => {
+    const run = makeRun({ endedAt: 2000, success: false });
+    expect(currentPhase(run).label).toBe("failed");
+  });
+
+  it("reports starting for an active run with no spans", () => {
+    const run = makeRun({ endedAt: undefined, spans: [] });
+    expect(currentPhase(run).label).toBe("starting");
+  });
+
+  it("uses the last open span's kind as the phase for an active run", () => {
+    const run = makeRun({
+      endedAt: undefined,
+      spans: [
+        { spanId: "a", name: "build-context", kind: "context", startedAt: 1000, endedAt: 1100, status: "ok" },
+        { spanId: "b", name: "anthropic", kind: "model", startedAt: 1100, status: "ok" },
+      ],
+    });
+    const phase = currentPhase(run);
+    expect(phase.label).toBe("model");
+    expect(phase.kind).toBe("model");
+    expect(phase.tool).toBeUndefined();
+  });
+
+  it("surfaces the active tool name when an open tool span is running", () => {
+    const run = makeRun({
+      endedAt: undefined,
+      spans: [
+        { spanId: "a", name: "anthropic", kind: "model", startedAt: 1000, endedAt: 1100, status: "ok" },
+        { spanId: "b", name: "web_search", kind: "tool", startedAt: 1100, status: "ok" },
+      ],
+    });
+    const phase = currentPhase(run);
+    expect(phase.label).toBe("tool");
+    expect(phase.tool).toBe("web_search");
+  });
+
+  it("falls back to the most recent span when none are open", () => {
+    const run = makeRun({
+      endedAt: undefined,
+      spans: [
+        { spanId: "a", name: "anthropic", kind: "model", startedAt: 1000, endedAt: 1100, status: "ok" },
+        { spanId: "b", name: "store", kind: "memory", startedAt: 1100, endedAt: 1200, status: "ok" },
+      ],
+    });
+    expect(currentPhase(run).label).toBe("memory");
+  });
+});

--- a/tests/web/run-timeline.test.ts
+++ b/tests/web/run-timeline.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { currentPhase, type AgentRun } from "../../apps/web/components/RunTimeline";
+import { currentPhase, type AgentRun } from "../../apps/web/components/run-timeline";
 
 function makeRun(overrides: Partial<AgentRun>): AgentRun {
   return {

--- a/tests/web/runTrace.test.ts
+++ b/tests/web/runTrace.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeSteps,
+  phasesPresent,
+  filterByPhase,
+  formatValue,
+} from '../../apps/web/components/runTrace';
+
+describe('normalizeSteps', () => {
+  it('reads { steps } and assigns indexes', () => {
+    const out = normalizeSteps({
+      steps: [
+        { phase: 'context', context: 'hi' },
+        { phase: 'model' },
+      ],
+    });
+    expect(out).toHaveLength(2);
+    expect(out[0].index).toBe(0);
+    expect(out[0].phase).toBe('context');
+    expect(out[0].context).toBe('hi');
+  });
+
+  it('coerces fuzzy phase names', () => {
+    const out = normalizeSteps([
+      { type: 'llm-call' },
+      { type: 'tool_selection' },
+      { type: 'persist-memory' },
+      { type: 'weird' },
+    ]);
+    expect(out[0].phase).toBe('model');
+    expect(out[1].phase).toBe('tool-selection');
+    expect(out[2].phase).toBe('memory');
+    expect(out[3].phase).toBe('other');
+  });
+
+  it('extracts inline and array tool calls', () => {
+    const inline = normalizeSteps([
+      { phase: 'tool-call', toolName: 'shell', args: { c: 1 }, result: 'ok' },
+    ]);
+    expect(inline[0].toolCalls).toHaveLength(1);
+    expect(inline[0].toolCalls[0].name).toBe('shell');
+    expect(inline[0].toolCalls[0].result).toBe('ok');
+
+    const arr = normalizeSteps([
+      { phase: 'tool-call', toolCalls: [{ name: 'http', input: {}, output: 1 }] },
+    ]);
+    expect(arr[0].toolCalls[0].name).toBe('http');
+    expect(arr[0].toolCalls[0].args).toEqual({});
+    expect(arr[0].toolCalls[0].result).toBe(1);
+  });
+
+  it('extracts memory ops and selected tools', () => {
+    const out = normalizeSteps([
+      {
+        phase: 'memory',
+        selectedTools: ['a', { name: 'b' }],
+        memoryOps: [{ op: 'promote', tier: 'long-term' }, 'noted'],
+      },
+    ]);
+    expect(out[0].selectedTools).toEqual(['a', 'b']);
+    expect(out[0].memoryOps).toEqual([
+      { op: 'promote', tier: 'long-term', content: undefined },
+      { op: 'noted' },
+    ]);
+  });
+
+  it('handles trace/traces wrappers and bad input', () => {
+    expect(normalizeSteps({ trace: [{ phase: 'model' }] })).toHaveLength(1);
+    expect(normalizeSteps({ traces: [{ phase: 'model' }] })).toHaveLength(1);
+    expect(normalizeSteps(null)).toEqual([]);
+  });
+});
+
+describe('phasesPresent / filterByPhase', () => {
+  const steps = normalizeSteps([
+    { phase: 'context' },
+    { phase: 'model' },
+    { phase: 'context' },
+  ]);
+  it('returns distinct phases in canonical order', () => {
+    expect(phasesPresent(steps)).toEqual(['context', 'model']);
+  });
+  it('filters by phase and passes through "all"', () => {
+    expect(filterByPhase(steps, 'context')).toHaveLength(2);
+    expect(filterByPhase(steps, 'all')).toHaveLength(3);
+  });
+});
+
+describe('formatValue', () => {
+  it('returns strings as-is and stringifies objects', () => {
+    expect(formatValue('x')).toBe('x');
+    expect(formatValue({ a: 1 })).toContain('"a": 1');
+    expect(formatValue(null)).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

**Wave 5 — the final UI layer.** Web + mobile interfaces built against the data/APIs merged in wave 4, by 3 parallel agents. Additive, **no new dependencies**.

## Verification ✅
- `pnpm --filter @karna/web build`: compiled successfully, 28/28 static pages
- `pnpm --filter @karna/web typecheck` + mobile `tsc --noEmit`: 0 errors
- `pnpm typecheck`: **28/28 packages**
- `pnpm test`: **214 files, 2168 tests, 0 failures**

## Implemented

| Area | Issues |
|---|---|
| **Web dashboards** | #579 usage/cost dashboard · #574 eval-results dashboard + drill-down · #582 session replay viewer · #583 real-time run timeline |
| **Web HITL / marketplace** | #615 marketplace browse/install · #586 pending-approvals queue (approve/deny/edit-args) · #611 run debugger panel |
| **Mobile** | #612 push notifications (approvals + run-completion, opt-in) · #586 pending-approvals UI in Tasks tab |

New thin gateway-proxy routes added where a UI needed one (approvals, marketplace, session traces), mirroring the existing `_gateway` proxy pattern.

## ⚠️ Honest caveat — visual verification
This UI is **code-complete and compiles/builds/CI-green**, but I could **not** visually verify rendering/interaction in a running Next.js/Expo app from this headless environment. Per the agreed plan, these issues will be closed **code-complete** and labelled `needs-visual-verification`. A click-through checklist follows separately. Please run `pnpm --filter @karna/web dev` and the Expo app to confirm the pixels.

This completes the trends-2026 backlog implementation across waves 1–5.

https://claude.ai/code/session_01Fjnt1mevfNwTgyEBEQDzku

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fjnt1mevfNwTgyEBEQDzku)_