### PR TITLE
feat: wire tool security/rate-limit/cache modules into AgentRuntime

### DIFF
--- a/agent/src/runtime.ts
+++ b/agent/src/runtime.ts
@@ -16,15 +16,40 @@ import type { AgentPersona } from "./context/system-prompt.js";
 import type { ChatMessage, ModelProvider, StreamEvent } from "./models/provider.js";
 import { routeModel, type AgentConfig } from "./models/router.js";
 import { ToolRegistry, type ToolDefinitionRuntime, type ToolPolicy, type ToolResult } from "./tools/registry.js";
-import { executeTool } from "./tools/executor.js";
+import { executeTool, type ExecuteToolOptions } from "./tools/executor.js";
 import { requiresApproval, requestApproval, type ApprovalCallback } from "./tools/approval.js";
 import { selectRelevantChatTools } from "./tools/selection.js";
+import { ToolRateLimiter, type ToolLimitConfig } from "./tools/rate-limiter.js";
+import { ToolResultCache, type ToolCacheConfig } from "./tools/result-cache.js";
+import { PolicyEngine, type PolicyRule } from "./tools/security/policy-engine.js";
 import { MemoryStore, type SaveMemoryInput } from "./memory/store.js";
 import type { Embedder } from "./memory/embedder.js";
 
 const logger = pino({ name: "agent-runtime" });
 
 // ─── Types ──────────────────────────────────────────────────────────────────
+
+/**
+ * Opt-in runtime feature wiring (trends-2026 modules).
+ *
+ * All fields are optional and default to inert values, so an unconfigured
+ * runtime behaves exactly as before:
+ *  - `toolRateLimits` empty  → limiter returns a no-op lease for every tool.
+ *  - `toolResultCache` empty → cache is disabled for every tool.
+ *  - `toolPolicyRules` empty → policy engine defaults to "allow" (but every
+ *    decision is still audited, so the hook is live and observable).
+ *  - `validateToolOutput` off → outputs are not schema-checked.
+ */
+export interface RuntimeFeatures {
+  /** Per-tool rate limit / concurrency config (Issue #552). */
+  toolRateLimits?: Record<string, ToolLimitConfig>;
+  /** Per-tool result-cache config (Issue #548). */
+  toolResultCache?: Record<string, ToolCacheConfig>;
+  /** Pre-execution policy rules (Issue #556). Default decision is "allow". */
+  toolPolicyRules?: PolicyRule[];
+  /** Validate tool outputs against their `outputSchema` when present (Issue #547). */
+  validateToolOutput?: boolean;
+}
 
 export interface RuntimeConfig {
   /** Context builder configuration. */
@@ -35,6 +60,8 @@ export interface RuntimeConfig {
   maxHistoryMessages?: number;
   /** Whether to extract and store memories automatically. */
   autoMemory?: boolean;
+  /** Opt-in feature wiring; inert by default. */
+  features?: RuntimeFeatures;
 }
 
 export interface AgentTurnInput {
@@ -122,6 +149,12 @@ export class AgentRuntime {
   private readonly memoryStore: MemoryStore | null;
   private readonly embedder: Embedder | null;
   private readonly config: Required<RuntimeConfig>;
+  /** Per-tool rate limiter (Issue #552). No-op for unconfigured tools. */
+  private readonly rateLimiter: ToolRateLimiter;
+  /** Per-tool result cache (Issue #548). Disabled for unconfigured tools. */
+  private readonly resultCache: ToolResultCache;
+  /** Pre-execution policy engine (Issue #556). Defaults to "allow", audited. */
+  private readonly policyEngine: PolicyEngine;
   private approvalCallback: ApprovalCallback | null = null;
   private streamCallback: StreamCallback | null = null;
   private running = false;
@@ -136,12 +169,24 @@ export class AgentRuntime {
     this.toolRegistry = toolRegistry;
     this.memoryStore = memoryStore ?? null;
     this.embedder = embedder ?? null;
+    const features = config?.features ?? {};
     this.config = {
       context: config?.context ?? {},
       maxToolIterations: config?.maxToolIterations ?? DEFAULT_MAX_TOOL_ITERATIONS,
       maxHistoryMessages: config?.maxHistoryMessages ?? DEFAULT_MAX_HISTORY,
       autoMemory: config?.autoMemory ?? true,
+      features,
     };
+    this.rateLimiter = new ToolRateLimiter(features.toolRateLimits ?? {});
+    this.resultCache = new ToolResultCache(features.toolResultCache ?? {});
+    this.policyEngine = new PolicyEngine(features.toolPolicyRules ?? [], {
+      defaultDecision: "allow",
+    });
+  }
+
+  /** Access the policy engine's audit log (Issue #556 observability). */
+  getPolicyAuditLog(): ReturnType<PolicyEngine["getAudit"]> {
+    return this.policyEngine.getAudit();
   }
 
   // ─── Lifecycle ──────────────────────────────────────────────────────────
@@ -446,9 +491,40 @@ export class AgentRuntime {
         continue;
       }
 
-      // Check approval
+      // Pre-execution policy check (Issue #556). Default decision is "allow",
+      // so behavior is unchanged unless rules are configured; every decision is
+      // audited regardless.
+      const policyEval = this.policyEngine.evaluate({
+        toolName: tool.name,
+        args: toolUse.input,
+        riskLevel: tool.riskLevel,
+        user: session.userId,
+        context: { sessionId: session.id, agentId: agent.id },
+      });
+      if (policyEval.decision === "deny") {
+        logger.warn({ toolName: tool.name, toolCallId: toolUse.id }, "Tool call denied by policy");
+        messages.push({
+          role: "tool",
+          content: JSON.stringify({ error: "Tool call denied by policy" }),
+          toolCallId: toolUse.id,
+          toolName: toolUse.name,
+        });
+        records.push({
+          id: toolUse.id,
+          name: toolUse.name,
+          input: toolUse.input,
+          result: { output: null, isError: true, errorMessage: "Denied by policy", durationMs: 0 },
+          approved: false,
+        });
+        continue;
+      }
+
+      // Check approval. The policy engine can also force approval for a tool
+      // that would otherwise auto-run.
+      const policyForcesApproval =
+        policyEval.decision === "require-approval" || policyEval.decision === "dry-run";
       let approved = true;
-      if (requiresApproval(tool, policy)) {
+      if (policyForcesApproval || requiresApproval(tool, policy)) {
         approved = await this.handleApproval(toolUse.id, tool, toolUse.input, session, agent);
       }
 
@@ -470,14 +546,26 @@ export class AgentRuntime {
         continue;
       }
 
-      // Execute tool
-      const result = await executeTool(tool, toolUse.input, {
-        sessionId: session.id,
-        agentId: agent.id,
-        userId: session.userId,
-        workingDirectory: undefined,
-        signal: this.abortController?.signal,
-      });
+      // Execute tool, threading the opt-in rate limiter / result cache /
+      // output validation (Issues #552, #548, #547). All are inert unless the
+      // corresponding tool is configured, so default behavior is unchanged.
+      const execOptions: ExecuteToolOptions = {
+        rateLimiter: this.rateLimiter,
+        cache: this.resultCache,
+        validateOutput: this.config.features.validateToolOutput ?? false,
+      };
+      const result = await executeTool(
+        tool,
+        toolUse.input,
+        {
+          sessionId: session.id,
+          agentId: agent.id,
+          userId: session.userId,
+          workingDirectory: undefined,
+          signal: this.abortController?.signal,
+        },
+        execOptions,
+      );
 
       messages.push({
         role: "tool",

--- a/tests/agent/runtime-feature-wiring.test.ts
+++ b/tests/agent/runtime-feature-wiring.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Session } from "@karna/shared/types/session.js";
+import { AgentRuntime } from "../../agent/src/runtime.js";
+import { ToolRegistry, type ToolDefinitionRuntime } from "../../agent/src/tools/registry.js";
+
+// The runtime selects its provider via routeModel(), so we mock it (mirroring
+// tests/agent/runtime-tool-denial.test.ts). Turn 1 requests the tool; turn 2
+// replies with text so the loop terminates.
+const routeMock = vi.hoisted(() => {
+  const calls: unknown[] = [];
+  const provider = {
+    name: "fake-provider",
+    async *chat(params: unknown) {
+      calls.push(params);
+      if (calls.length === 1) {
+        yield { type: "tool_use" as const, id: "c1", name: "danger_tool", input: { x: 1 } };
+        yield { type: "done" as const };
+      } else {
+        yield { type: "text" as const, text: "all done" };
+        yield { type: "done" as const };
+      }
+    },
+  };
+  return { calls, provider };
+});
+
+vi.mock("../../agent/src/models/router.js", () => ({
+  routeModel: () => ({ provider: routeMock.provider, model: "fake-model", complexity: "simple" }),
+}));
+
+function makeSession(): Session {
+  const now = Date.now();
+  return {
+    id: "s1",
+    channelType: "webchat",
+    channelId: "c1",
+    userId: "u1",
+    status: "active",
+    createdAt: now,
+    updatedAt: now,
+    context: { tools: ["danger_tool"] },
+  } as unknown as Session;
+}
+
+const AGENT = {
+  id: "karna-general",
+  name: "Karna",
+  defaultProvider: "openai",
+  defaultModel: "fake-model",
+} as never;
+
+function registerDangerTool(registry: ToolRegistry, exec: () => Promise<unknown>) {
+  registry.register({
+    name: "danger_tool",
+    description: "does something",
+    parameters: { type: "object", properties: {} },
+    riskLevel: "high",
+    requiresApproval: false,
+    timeout: 5000,
+    execute: exec,
+  } as ToolDefinitionRuntime);
+}
+
+describe("runtime feature wiring (#556/#552/#548/#547)", () => {
+  beforeEach(() => {
+    routeMock.calls.length = 0;
+  });
+
+  it("a policy 'deny' rule blocks the tool without executing it", async () => {
+    const registry = new ToolRegistry();
+    const exec = vi.fn(async () => "should-not-run");
+    registerDangerTool(registry, exec);
+
+    const rt = new AgentRuntime(registry, undefined, undefined, {
+      features: {
+        toolPolicyRules: [
+          { id: "deny-danger", decision: "deny", priority: 100, when: { tools: ["danger_tool"] } },
+        ],
+      },
+    });
+    await rt.init();
+
+    await rt.run({ message: "do it", session: makeSession(), agent: AGENT, conversationHistory: [] });
+
+    expect(exec).not.toHaveBeenCalled();
+    const audit = rt.getPolicyAuditLog();
+    expect(audit.some((e) => e.decision === "deny" && e.input.toolName === "danger_tool")).toBe(true);
+  });
+
+  it("default-allow runs the tool and audits the decision", async () => {
+    const registry = new ToolRegistry();
+    const exec = vi.fn(async () => "ran");
+    registerDangerTool(registry, exec);
+
+    const rt = new AgentRuntime(registry, undefined, undefined, {});
+    // The tool is high-risk, so it still flows through the approval gate; approve
+    // it so we exercise the (allowed) execution + audit path.
+    rt.setApprovalCallback(async (request) => ({
+      toolCallId: request.toolCallId,
+      approved: true,
+      respondedAt: Date.now(),
+    }));
+    await rt.init();
+
+    await rt.run({ message: "do it", session: makeSession(), agent: AGENT, conversationHistory: [] });
+
+    expect(exec).toHaveBeenCalledTimes(1);
+    const audit = rt.getPolicyAuditLog();
+    expect(audit.some((e) => e.decision === "allow" && e.input.toolName === "danger_tool")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Wiring pass — activates several merged-but-dormant trends-2026 modules in the **live** `AgentRuntime` tool path. **Inert by default**: behavior is unchanged unless `RuntimeConfig.features` is configured.

## What's now live
- **#556 Policy engine** — pre-execution check before every tool call. Default decision `allow` (no behavior change), but **every decision is audited** (`AgentRuntime.getPolicyAuditLog()`), a `deny` rule blocks execution, and `require-approval`/`dry-run` force the approval flow.
- **#552 Rate limiter** + **#548 result cache** — threaded into `executeTool` via the existing `ExecuteToolOptions`. Empty config ⇒ no-op lease / cache disabled per tool.
- **#547 output validation** — optional via `features.validateToolOutput`.

New config surface: `RuntimeConfig.features: RuntimeFeatures` (all fields optional).

## Honest scoping note
**Anthropic prompt caching (#592) is deliberately NOT wired here.** It needs the `ChatParams`/provider interface extended to carry cache directives — a separate non-breaking change. Faking it through the current interface wasn't possible, so it's called out as follow-up rather than claimed done.

## Verification
- `pnpm typecheck` → 28/28 packages
- `pnpm test` → 216 files, **2176 tests, 0 failures**
- New integration test (`runtime-feature-wiring.test.ts`) proves the policy hook is live end-to-end: a `deny` rule blocks the tool (spy never called) and the decision is audited; default-allow runs and audits.

https://claude.ai/code/session_01Fjnt1mevfNwTgyEBEQDzku

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fjnt1mevfNwTgyEBEQDzku)_