### PR TITLE
feat: wire Anthropic prompt caching end-to-end (#592)

### DIFF
--- a/agent/src/models/anthropic.ts
+++ b/agent/src/models/anthropic.ts
@@ -32,6 +32,11 @@ export class AnthropicProvider implements ModelProvider {
     const messages = this.buildMessages(params);
     const tools = params.tools ? this.buildTools(params.tools) : undefined;
 
+    // Prompt caching (#592): when a cache directive is present, mark the stable
+    // prefix (tools block + system prompt) with `cache_control`. Cache reads are
+    // ~0.1x input price, so this pays off across multi-turn / multi-tool loops.
+    const { system } = this.applyPromptCache(params, tools);
+
     let attempt = 0;
 
     while (attempt < MAX_RETRIES) {
@@ -40,7 +45,7 @@ export class AnthropicProvider implements ModelProvider {
           model,
           max_tokens: maxTokens,
           messages,
-          system: params.systemPrompt ?? undefined,
+          system: system as never,
           temperature: params.temperature ?? undefined,
           stop_sequences: params.stopSequences ?? undefined,
           tools: tools && tools.length > 0 ? tools : undefined,
@@ -140,6 +145,35 @@ export class AnthropicProvider implements ModelProvider {
     }
 
     return messages;
+  }
+
+  /**
+   * Apply prompt-cache breakpoints (#592) to the stable prefix. Mutates the
+   * passed `tools` array in place (attaching `cache_control` to the last tool,
+   * which caches the whole tools block) and returns the `system` value to send
+   * — either the plain string, or a cache-annotated text block array.
+   *
+   * When no cache directive is present this is a pass-through (returns the plain
+   * system prompt), so behavior is unchanged.
+   */
+  private applyPromptCache(
+    params: ChatParams,
+    tools: Tool[] | undefined,
+  ): { system: string | Array<{ type: "text"; text: string; cache_control?: unknown }> | undefined } {
+    const cache = params.cache;
+    if (!cache) {
+      return { system: params.systemPrompt ?? undefined };
+    }
+    const cacheControl = { type: "ephemeral" as const, ttl: cache.ttl ?? "5m" };
+
+    if (tools && tools.length > 0 && (cache.tools ?? true)) {
+      (tools[tools.length - 1] as Tool & { cache_control?: unknown }).cache_control = cacheControl;
+    }
+
+    if (params.systemPrompt && (cache.system ?? true)) {
+      return { system: [{ type: "text", text: params.systemPrompt, cache_control: cacheControl }] };
+    }
+    return { system: params.systemPrompt ?? undefined };
   }
 
   private buildTools(tools: ChatTool[]): Tool[] {

--- a/agent/src/models/provider.ts
+++ b/agent/src/models/provider.ts
@@ -53,6 +53,23 @@ export interface ChatParams {
   temperature?: number;
   maxTokens?: number;
   stopSequences?: string[];
+  /**
+   * Optional prompt-caching directive (Issue #592). Providers that support
+   * prompt caching (currently Anthropic) place `cache_control` breakpoints on
+   * the stable prefix (system prompt + tool definitions). Ignored by providers
+   * that don't support it, so it is fully non-breaking.
+   */
+  cache?: PromptCacheDirective;
+}
+
+/** Where a provider should place prompt-cache breakpoints (Issue #592). */
+export interface PromptCacheDirective {
+  /** Cache the system prompt block. Default true when `cache` is set. */
+  system?: boolean;
+  /** Cache the tool-definitions block. Default true when `cache` is set. */
+  tools?: boolean;
+  /** Cache lifetime hint. Default "5m". */
+  ttl?: "5m" | "1h";
 }
 
 /**

--- a/agent/src/runtime.ts
+++ b/agent/src/runtime.ts
@@ -49,6 +49,11 @@ export interface RuntimeFeatures {
   toolPolicyRules?: PolicyRule[];
   /** Validate tool outputs against their `outputSchema` when present (Issue #547). */
   validateToolOutput?: boolean;
+  /**
+   * Enable Anthropic prompt caching on the stable prefix (system + tools).
+   * Inert for providers that don't support it. (Issue #592)
+   */
+  promptCache?: { enabled: boolean; ttl?: "5m" | "1h" };
 }
 
 export interface RuntimeConfig {
@@ -426,11 +431,13 @@ export class AgentRuntime {
     const toolUses: Array<{ id: string; name: string; input: Record<string, unknown> }> = [];
     let usage = { inputTokens: 0, outputTokens: 0 };
 
+    const promptCache = this.config.features.promptCache;
     const stream = provider.chat({
       messages,
       systemPrompt,
       model,
       tools: tools.length > 0 ? tools : undefined,
+      cache: promptCache?.enabled ? { ttl: promptCache.ttl ?? "5m" } : undefined,
     });
 
     for await (const event of stream) {

--- a/tests/agent/prompt-cache-wiring.test.ts
+++ b/tests/agent/prompt-cache-wiring.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { AnthropicProvider } from "../../agent/src/models/anthropic.js";
+import type { ChatParams } from "../../agent/src/models/provider.js";
+
+interface ToolWithCache {
+  name: string;
+  cache_control?: { type: string; ttl: string };
+}
+interface SystemBlock {
+  type: "text";
+  text: string;
+  cache_control?: { type: string; ttl: string };
+}
+
+// Exercise the private applyPromptCache helper (mirrors the pattern in
+// model-tool-messages.test.ts) — no live SDK needed.
+function applyCache(
+  provider: AnthropicProvider,
+  params: ChatParams,
+  tools: ToolWithCache[] | undefined,
+): { system: unknown } {
+  return (
+    provider as unknown as {
+      applyPromptCache(p: ChatParams, t: ToolWithCache[] | undefined): { system: unknown };
+    }
+  ).applyPromptCache(params, tools);
+}
+
+const provider = new AnthropicProvider("test-key");
+
+const base: ChatParams = {
+  systemPrompt: "You are Karna.",
+  messages: [{ role: "user", content: "hi" }],
+};
+
+describe("Anthropic prompt caching wiring (#592)", () => {
+  it("is a pass-through when no cache directive is set", () => {
+    const tools: ToolWithCache[] = [{ name: "a" }, { name: "b" }];
+    const { system } = applyCache(provider, base, tools);
+    expect(system).toBe("You are Karna.");
+    expect(tools[1].cache_control).toBeUndefined();
+  });
+
+  it("annotates system + last tool when cache is requested", () => {
+    const tools: ToolWithCache[] = [{ name: "a" }, { name: "b" }];
+    const { system } = applyCache(provider, { ...base, cache: { ttl: "1h" } }, tools);
+    const block = (system as SystemBlock[])[0];
+    expect(block.cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+    // Only the last tool is marked (caches the whole tools prefix).
+    expect(tools[1].cache_control).toEqual({ type: "ephemeral", ttl: "1h" });
+    expect(tools[0].cache_control).toBeUndefined();
+  });
+
+  it("respects system:false / tools:false toggles", () => {
+    const tools: ToolWithCache[] = [{ name: "a" }];
+    const { system } = applyCache(
+      provider,
+      { ...base, cache: { system: false, tools: false } },
+      tools,
+    );
+    expect(system).toBe("You are Karna."); // not annotated
+    expect(tools[0].cache_control).toBeUndefined();
+  });
+
+  it("defaults ttl to 5m", () => {
+    const tools: ToolWithCache[] = [{ name: "a" }];
+    applyCache(provider, { ...base, cache: {} }, tools);
+    expect(tools[0].cache_control).toEqual({ type: "ephemeral", ttl: "5m" });
+  });
+});


### PR DESCRIPTION
## Summary

Implementation wave 1 (of the "100 implementation tasks" effort). Completes the **previously-deferred prompt caching (#592)** — the one item I explicitly declined to fake earlier because it needed a provider-interface change. Now done properly.

## Changes
- **`ChatParams`** gains optional `cache?: PromptCacheDirective` (`{ system?, tools?, ttl? }`). Providers without caching support ignore it → **non-breaking**.
- **`AnthropicProvider.applyPromptCache`** attaches `cache_control` to the system block + the last tool (caching the whole stable prefix). Pass-through when no directive is set.
- **`AgentRuntime`** threads `features.promptCache` → `ChatParams.cache`, **off by default**.

Cache reads are ~0.1× input price, so this cuts cost/latency across multi-turn, multi-tool loops once enabled via `RuntimeConfig.features.promptCache`.

## Verification
- `pnpm typecheck` → 28/28 packages
- `pnpm test` → 216 files, **2175 tests, 0 failures**
- New `prompt-cache-wiring.test.ts` (4 tests) verifies annotation, toggles, ttl default, and pass-through — via the provider's request-build logic, no live SDK.

This is the first of an ongoing series turning merged-but-dormant modules into live, configured features. Each lands as its own green PR.

https://claude.ai/code/session_01Fjnt1mevfNwTgyEBEQDzku

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fjnt1mevfNwTgyEBEQDzku)_