### PR TITLE
feat: mount gateway MCP server over HTTP, config-gated (#544)

### DIFF
--- a/gateway/src/config/schema.ts
+++ b/gateway/src/config/schema.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { McpExposeConfigSchema } from "../mcp/server.js";
 
 // ─── Gateway Config ─────────────────────────────────────────────────────────
 
@@ -24,6 +25,11 @@ export const GatewayConfigSchema = z.object({
       origins: z.array(z.string()).default([]),
     })
     .default({}),
+  /**
+   * Expose selected built-in tools as an MCP server over HTTP (Issue #544).
+   * OFF by default; even when enabled, only allowlisted tools are exposed.
+   */
+  mcp: McpExposeConfigSchema.optional(),
 });
 
 export type GatewayConfig = z.infer<typeof GatewayConfigSchema>;

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -38,6 +38,9 @@ import { registerApiRoutes } from "./routes/api.js";
 import { registerControlRoutes } from "./routes/control.js";
 import { registerWorkflowRoutes } from "./routes/workflows.js";
 import { registerRuntimeRoutes } from "./routes/runtime.js";
+import { registerMcpRoutes } from "./routes/mcp.js";
+import { McpServer } from "./mcp/server.js";
+import { createRegistryToolProvider } from "./mcp/tool-provider.js";
 import { AuditLogger } from "./audit/logger.js";
 import { TraceCollector } from "./observability/trace-collector.js";
 import {
@@ -266,6 +269,26 @@ async function main(): Promise<void> {
   registerWorkflowRoutes(server, workflowEngine);
   registerControlRoutes(server, { sessionManager, connectedClients, auditLogger, traceCollector });
   registerOpenApiRoutes(server);
+
+  // ─── MCP Server (Issue #544) — OFF by default ───────────────────────────
+  // When enabled, expose allowlisted built-in tools over JSON-RPC-over-HTTP.
+  // Tools are loaded lazily so the agent stays out of the static import graph.
+  if (config.gateway.mcp?.enabled) {
+    const { ToolRegistry } = await import("@karna/agent/tools/registry.js");
+    const { registerBuiltinTools } = await import("@karna/agent/tools/builtin/index.js");
+    const mcpRegistry = new ToolRegistry();
+    registerBuiltinTools(mcpRegistry);
+    const provider = createRegistryToolProvider(mcpRegistry, () => ({
+      sessionId: `mcp-${nanoid()}`,
+      agentId: "mcp-server",
+    }));
+    const mcpServer = new McpServer(provider, config.gateway.mcp, { logger: server.log });
+    registerMcpRoutes(server, mcpServer);
+    server.log.info(
+      { allowlisted: config.gateway.mcp.allowlist.length },
+      "MCP server mounted at POST /mcp",
+    );
+  }
 
   // ─── WebSocket Route ────────────────────────────────────────────────────
 

--- a/gateway/src/mcp/server.ts
+++ b/gateway/src/mcp/server.ts
@@ -69,8 +69,15 @@ export interface ToolProvider {
   get(name: string): ExposableTool | undefined;
 }
 
+/**
+ * Minimal logger surface used by the server. Structurally satisfied by both a
+ * pino `Logger` and Fastify's `FastifyBaseLogger`, so the server can be mounted
+ * on the gateway without a nominal-type clash.
+ */
+export type McpLogger = Pick<Logger, "warn">;
+
 export interface McpServerOptions {
-  logger?: Logger;
+  logger?: McpLogger;
 }
 
 // ---------------------------------------------------------------------------
@@ -80,7 +87,7 @@ export interface McpServerOptions {
 export class McpServer {
   private readonly config: McpExposeConfig;
   private readonly provider: ToolProvider;
-  private readonly logger?: Logger;
+  private readonly logger?: McpLogger;
   private readonly allowSet: Set<string>;
 
   constructor(

--- a/gateway/src/mcp/tool-provider.ts
+++ b/gateway/src/mcp/tool-provider.ts
@@ -1,0 +1,64 @@
+/**
+ * Adapter: agent `ToolRegistry` → MCP `ToolProvider` (Issue #544).
+ *
+ * The {@link McpServer} consumes a minimal {@link ToolProvider} (`list()` /
+ * `get()` returning {@link ExposableTool}s). The agent's `ToolRegistry` exposes
+ * a richer runtime shape whose `execute` takes a `ToolExecutionContext`. This
+ * adapter bridges the two without importing the agent at runtime — it only
+ * relies on the structural shape, keeping the gateway/agent boundary clean.
+ *
+ * Note: the MCP server still filters everything through its allowlist + the
+ * `available` flag, so this adapter exposing a tool does NOT mean it is
+ * reachable unless an operator allowlists it.
+ */
+import type { ExposableTool, ToolProvider } from "./server.js";
+
+/** Execution context the agent's tool handlers expect. */
+export interface ToolExecutionContextLike {
+  sessionId: string;
+  agentId: string;
+  userId?: string;
+  workingDirectory?: string;
+  signal?: AbortSignal;
+}
+
+/** Minimal runtime-tool shape (structurally satisfied by `ToolDefinitionRuntime`). */
+export interface RuntimeToolLike {
+  name: string;
+  description: string;
+  parameters: { type: "object"; properties: Record<string, unknown>; required?: string[] };
+  execute: (input: Record<string, unknown>, context: ToolExecutionContextLike) => Promise<unknown>;
+}
+
+/** Minimal registry surface used by the adapter (satisfied by `ToolRegistry`). */
+export interface RegistryLike {
+  getTools(): RuntimeToolLike[];
+  get(name: string): RuntimeToolLike | undefined;
+}
+
+/**
+ * Build a {@link ToolProvider} backed by a `ToolRegistry`. Every MCP `tools/call`
+ * runs the underlying tool with a context produced by `contextFactory` (so each
+ * call can carry a fresh abort signal / synthetic session identity).
+ */
+export function createRegistryToolProvider(
+  registry: RegistryLike,
+  contextFactory: () => ToolExecutionContextLike,
+): ToolProvider {
+  const toExposable = (tool: RuntimeToolLike): ExposableTool => ({
+    name: tool.name,
+    description: tool.description,
+    inputSchema: tool.parameters as Record<string, unknown>,
+    execute: (input: unknown) =>
+      tool.execute((input ?? {}) as Record<string, unknown>, contextFactory()),
+    available: true,
+  });
+
+  return {
+    list: () => registry.getTools().map(toExposable),
+    get: (name: string) => {
+      const tool = registry.get(name);
+      return tool ? toExposable(tool) : undefined;
+    },
+  };
+}

--- a/gateway/src/routes/mcp.ts
+++ b/gateway/src/routes/mcp.ts
@@ -1,0 +1,33 @@
+/**
+ * MCP server HTTP transport (Issue #544).
+ *
+ * Mounts the gateway's {@link McpServer} on a single JSON-RPC-over-HTTP
+ * endpoint (POST /mcp). External MCP clients can `initialize`, `tools/list`,
+ * and `tools/call` against karna's allowlisted built-in tools.
+ *
+ * Registered ONLY when `gateway.mcp.enabled` is true, so default startup is
+ * unchanged. The body is the raw JSON-RPC payload (single request or batch);
+ * the server returns the JSON-RPC response, or 204 for notification-only
+ * payloads that produce no response.
+ */
+import type { FastifyInstance } from "fastify";
+import type { McpServer } from "../mcp/server.js";
+
+export function registerMcpRoutes(app: FastifyInstance, mcpServer: McpServer): void {
+  // Accept the body as a raw string so handleRaw owns parsing/JSON-RPC errors.
+  app.post("/mcp", async (request, reply) => {
+    const raw =
+      typeof request.body === "string" ? request.body : JSON.stringify(request.body ?? {});
+    const responseJson = await mcpServer.handleRaw(raw);
+    if (responseJson === undefined) {
+      // Notification(s) only — no JSON-RPC response per spec.
+      return reply.status(204).send();
+    }
+    return reply.header("content-type", "application/json").send(responseJson);
+  });
+
+  // Lightweight liveness probe for MCP clients / dashboards.
+  app.get("/mcp", async (_request, reply) => {
+    return reply.send({ server: "karna-gateway", transport: "http", enabled: mcpServer.enabled });
+  });
+}

--- a/tests/gateway/mcp-http-route.test.ts
+++ b/tests/gateway/mcp-http-route.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import Fastify from "fastify";
+import { McpServer } from "../../gateway/src/mcp/server.js";
+import { registerMcpRoutes } from "../../gateway/src/routes/mcp.js";
+import {
+  createRegistryToolProvider,
+  type RegistryLike,
+  type RuntimeToolLike,
+} from "../../gateway/src/mcp/tool-provider.js";
+
+// A minimal registry standing in for the agent's ToolRegistry.
+function makeRegistry(tools: RuntimeToolLike[]): RegistryLike {
+  const map = new Map(tools.map((t) => [t.name, t]));
+  return { getTools: () => [...map.values()], get: (n) => map.get(n) };
+}
+
+const echoTool: RuntimeToolLike = {
+  name: "echo",
+  description: "echoes input back",
+  parameters: { type: "object", properties: { text: { type: "string" } } },
+  execute: async (input) => ({ echoed: input }),
+};
+
+describe("MCP HTTP route (#544)", () => {
+  let app: ReturnType<typeof Fastify>;
+
+  async function build(allowlist: string[], enabled = true) {
+    app = Fastify();
+    let lastCtxAgentId = "";
+    const provider = createRegistryToolProvider(makeRegistry([echoTool]), () => {
+      lastCtxAgentId = "mcp-server";
+      return { sessionId: "mcp-test", agentId: lastCtxAgentId };
+    });
+    const mcp = new McpServer(provider, { enabled, allowlist });
+    registerMcpRoutes(app, mcp);
+    await app.ready();
+    return app;
+  }
+
+  it("liveness GET reports enabled state", async () => {
+    await build(["echo"]);
+    const res = await app.inject({ method: "GET", url: "/mcp" });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ server: "karna-gateway", enabled: true });
+  });
+
+  it("tools/list returns only allowlisted tools", async () => {
+    await build(["echo"]);
+    const res = await app.inject({
+      method: "POST",
+      url: "/mcp",
+      payload: { jsonrpc: "2.0", id: 1, method: "tools/list" },
+    });
+    expect(res.statusCode).toBe(200);
+    const names = res.json().result.tools.map((t: { name: string }) => t.name);
+    expect(names).toEqual(["echo"]);
+  });
+
+  it("tools/call executes the underlying tool with a synthetic context", async () => {
+    await build(["echo"]);
+    const res = await app.inject({
+      method: "POST",
+      url: "/mcp",
+      payload: {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: "echo", arguments: { text: "hi" } },
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    // Result is wrapped as MCP content; the echoed payload should be present.
+    expect(JSON.stringify(res.json().result)).toContain("hi");
+  });
+
+  it("does not expose tools that are not allowlisted", async () => {
+    await build([]); // enabled but empty allowlist => nothing exposed
+    const res = await app.inject({
+      method: "POST",
+      url: "/mcp",
+      payload: { jsonrpc: "2.0", id: 3, method: "tools/list" },
+    });
+    expect(res.json().result.tools).toEqual([]);
+  });
+
+  it("returns a JSON-RPC parse error for malformed bodies", async () => {
+    await build(["echo"]);
+    const res = await app.inject({
+      method: "POST",
+      url: "/mcp",
+      headers: { "content-type": "text/plain" },
+      payload: "}{ not json",
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().error.code).toBe(-32700);
+  });
+});
+
+describe("createRegistryToolProvider adapter (#544)", () => {
+  it("maps runtime tools to ExposableTools and runs execute with context", async () => {
+    let seenContext: unknown;
+    const tool: RuntimeToolLike = {
+      name: "probe",
+      description: "d",
+      parameters: { type: "object", properties: {} },
+      execute: async (input, ctx) => {
+        seenContext = ctx;
+        return { input };
+      },
+    };
+    const provider = createRegistryToolProvider(makeRegistry([tool]), () => ({
+      sessionId: "s1",
+      agentId: "a1",
+    }));
+    const exposed = provider.list();
+    expect(exposed).toHaveLength(1);
+    expect(exposed[0]).toMatchObject({ name: "probe", available: true });
+    expect(exposed[0].inputSchema).toEqual({ type: "object", properties: {} });
+
+    await exposed[0].execute({ x: 1 });
+    expect(seenContext).toEqual({ sessionId: "s1", agentId: "a1" });
+
+    expect(provider.get("probe")?.name).toBe("probe");
+    expect(provider.get("missing")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Implementation wave 2. Turns the merged-but-dormant **gateway MCP server (#544)** into a live, opt-in feature — Karna can now act as an MCP *server*, exposing its built-in tools to external MCP clients over HTTP.

## Changes
- **`ToolRegistry → ToolProvider` adapter** (`mcp/tool-provider.ts`): structural-only bridge (no runtime agent import) mapping `ToolDefinitionRuntime.parameters` → `ExposableTool.inputSchema`, supplying a synthetic `ToolExecutionContext` per `tools/call`.
- **HTTP transport** (`routes/mcp.ts`): `POST /mcp` handles raw JSON-RPC (`initialize`, `tools/list`, `tools/call`; `204` for notification-only payloads). `GET /mcp` is a liveness probe.
- **Config**: `gateway.mcp` (`McpExposeConfigSchema`), optional. Wired in `index.ts` **only when `gateway.mcp.enabled` is true**, loading built-in tools lazily so the agent stays out of the gateway's static import graph.
- `McpServerOptions.logger` widened to a minimal structural type so Fastify's logger satisfies it without a nominal clash.

## Safety
**OFF by default.** Even when enabled, the allowlist defaults to **empty** (nothing exposed) and unavailable tools are hidden. Default startup is unchanged (the `if` block is skipped when `mcp` is undefined).

## Verification
- `pnpm typecheck` → 28/28 packages
- `pnpm test` → 217 files, **2181 tests, 0 failures** (+6 new)
- New `mcp-http-route.test.ts` covers liveness, allowlist filtering, `tools/call` execution with context, empty-allowlist exposure, JSON-RPC parse errors, and the adapter mapping.

Part of the ongoing wave-based effort turning dormant modules into live, config-gated features. Each lands as its own green PR.

https://claude.ai/code/session_01Fjnt1mevfNwTgyEBEQDzku

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fjnt1mevfNwTgyEBEQDzku)_