### PR TITLE
feat(web): a11y + motion polish for Modal, DataTable, ChatMessage

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -87,6 +87,23 @@ textarea:focus-visible {
     0 0 0 4px var(--color-accent-500);
 }
 
+/* ===== Shared entrance animations ===== */
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+@keyframes modalIn {
+  from { opacity: 0; transform: translateY(8px) scale(0.98); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+@keyframes messageIn {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.animate-fade-in { animation: fadeIn 160ms ease-out; }
+.animate-modal-in { animation: modalIn 180ms cubic-bezier(0.16, 1, 0.3, 1); }
+.animate-message-in { animation: messageIn 200ms ease-out; }
+
 /* Dynamic viewport height for mobile browsers */
 .h-dvh {
   height: 100dvh;

--- a/apps/web/components/ChatMessage.tsx
+++ b/apps/web/components/ChatMessage.tsx
@@ -25,6 +25,8 @@ function ToolCallDisplay({
     <div className="mt-2 rounded-lg border border-dark-600 bg-dark-800/50 overflow-hidden">
       <button
         onClick={() => setExpanded(!expanded)}
+        aria-expanded={expanded}
+        aria-label={`${expanded ? "Collapse" : "Expand"} tool call ${toolCall.toolName}`}
         className="flex items-center gap-2 w-full px-3 py-2 text-sm text-dark-300 hover:bg-dark-700/50 transition-colors"
       >
         <Wrench size={14} />
@@ -69,12 +71,14 @@ function ToolCallDisplay({
             <div className="flex gap-2 pt-1">
               <button
                 onClick={() => onApproval(toolCall.id, true)}
+                aria-label={`Approve tool call ${toolCall.toolName}`}
                 className="px-3 py-1 text-xs font-medium rounded bg-success-500 text-white hover:bg-success-400 transition-colors"
               >
                 Approve
               </button>
               <button
                 onClick={() => onApproval(toolCall.id, false)}
+                aria-label={`Reject tool call ${toolCall.toolName}`}
                 className="px-3 py-1 text-xs font-medium rounded bg-danger-500 text-white hover:bg-danger-400 transition-colors"
               >
                 Reject
@@ -95,7 +99,7 @@ export function ChatMessage({ message, onToolApproval }: ChatMessageProps) {
   return (
     <div
       className={cn(
-        "flex gap-3 px-4 py-3",
+        "flex gap-3 px-4 py-3 animate-message-in",
         isUser && "flex-row-reverse",
       )}
     >

--- a/apps/web/components/DataTable.tsx
+++ b/apps/web/components/DataTable.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { ChevronUp, ChevronDown, ChevronLeft, ChevronRight } from "lucide-react";
+import { ChevronUp, ChevronDown, ChevronLeft, ChevronRight, ChevronsUpDown } from "lucide-react";
 import { useState, useMemo } from "react";
 
 export interface Column<T> {
@@ -68,24 +68,48 @@ export function DataTable<T extends Record<string, any>>({
         <table className="w-full text-sm whitespace-nowrap">
           <thead>
             <tr className="border-b border-dark-700">
-              {columns.map((col) => (
-                <th
-                  key={col.key}
-                  className={cn(
-                    "px-4 py-3 text-left text-xs font-medium text-dark-400 uppercase tracking-wider",
-                    col.sortable && "cursor-pointer select-none hover:text-dark-200",
-                    col.className,
-                  )}
-                  onClick={col.sortable ? () => handleSort(col.key) : undefined}
-                >
-                  <div className="flex items-center gap-1">
-                    {col.label}
-                    {col.sortable && sortKey === col.key && (
-                      sortDir === "asc" ? <ChevronUp size={14} /> : <ChevronDown size={14} />
+              {columns.map((col) => {
+                const isSorted = col.sortable && sortKey === col.key;
+                const ariaSort = isSorted
+                  ? sortDir === "asc"
+                    ? "ascending"
+                    : "descending"
+                  : col.sortable
+                    ? "none"
+                    : undefined;
+                return (
+                  <th
+                    key={col.key}
+                    scope="col"
+                    aria-sort={ariaSort}
+                    className={cn(
+                      "sticky top-0 z-10 bg-dark-800 px-4 py-3 text-left text-xs font-medium text-dark-400 uppercase tracking-wider",
+                      col.className,
                     )}
-                  </div>
-                </th>
-              ))}
+                  >
+                    {col.sortable ? (
+                      <button
+                        type="button"
+                        onClick={() => handleSort(col.key)}
+                        className="flex items-center gap-1 select-none uppercase tracking-wider hover:text-dark-200 transition-colors"
+                      >
+                        {col.label}
+                        {isSorted ? (
+                          sortDir === "asc" ? (
+                            <ChevronUp size={14} />
+                          ) : (
+                            <ChevronDown size={14} />
+                          )
+                        ) : (
+                          <ChevronsUpDown size={14} className="opacity-40" />
+                        )}
+                      </button>
+                    ) : (
+                      <span className="flex items-center gap-1">{col.label}</span>
+                    )}
+                  </th>
+                );
+              })}
             </tr>
           </thead>
           <tbody className="divide-y divide-dark-700/50">

--- a/apps/web/components/Modal.tsx
+++ b/apps/web/components/Modal.tsx
@@ -41,27 +41,35 @@ export function Modal({ open, onClose, title, children, className, size = "md" }
 
   if (!open) return null;
 
+  const titleId = title ? "modal-title" : undefined;
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       {/* Backdrop */}
       <div
-        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm animate-fade-in"
         onClick={onClose}
       />
 
       {/* Dialog */}
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
         className={cn(
-          "relative w-full mx-4 rounded-xl border border-dark-700 bg-dark-800 shadow-2xl",
+          "relative w-full mx-4 rounded-xl border border-dark-700 bg-dark-800 shadow-2xl animate-modal-in",
           sizeClasses[size],
           className,
         )}
       >
         {title && (
           <div className="flex items-center justify-between px-5 py-4 border-b border-dark-700">
-            <h3 className="text-base font-semibold text-white">{title}</h3>
+            <h3 id={titleId} className="text-base font-semibold text-white">
+              {title}
+            </h3>
             <button
               onClick={onClose}
+              aria-label="Close dialog"
               className="p-1 rounded-md text-dark-400 hover:text-white hover:bg-dark-700 transition-colors"
             >
               <X size={18} />


### PR DESCRIPTION
## Summary

UI polish **wave 2** — accessibility + tasteful motion across more shared dashboard components. Wider coverage than wave 1, same quality bar.

## Changes
- **`globals.css`** — shared `fadeIn` / `modalIn` / `messageIn` keyframes + utility classes. Covered by the existing `prefers-reduced-motion` guard, so they no-op for motion-sensitive users.
- **`Modal`** — proper dialog semantics (`role="dialog"`, `aria-modal`, `aria-labelledby` wired to the title), accessible close-button label, and a backdrop fade + dialog scale-in entrance.
- **`DataTable`** — sortable headers are now real `<button>`s (**keyboard operable**), headers carry `scope="col"` + `aria-sort` (ascending/descending/none), an unsorted-affordance icon, and the header row is **sticky** on vertical scroll.
- **`ChatMessage`** — `aria-expanded` on the tool-call toggle, descriptive `aria-label`s on approve/reject, and a subtle message entrance animation.

No API or behavior changes — accessibility/visual only.

## Verification
- web `typecheck` → clean
- `next build` → compiled successfully, **28/28 static pages**

Part of the ongoing series of real, reviewable UI waves (one green PR each) rather than mass-generated tweaks.

https://claude.ai/code/session_01Fjnt1mevfNwTgyEBEQDzku

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fjnt1mevfNwTgyEBEQDzku)_