### PR TITLE
feat(web): shared Skeleton component + skeleton loading for catalogs

### DIFF
--- a/apps/web/app/dashboard/skills/page.tsx
+++ b/apps/web/app/dashboard/skills/page.tsx
@@ -5,6 +5,7 @@ import { Puzzle, Search, Info } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/Badge";
 import { Modal } from "@/components/Modal";
+import { SkeletonCardGrid } from "@/components/Skeleton";
 
 interface Skill {
   id: string;
@@ -136,9 +137,7 @@ export default function SkillsPage() {
 
       {/* Skill grid */}
       {isLoading ? (
-        <div className="rounded-xl border border-dark-700 bg-dark-800 px-5 py-12 text-center text-sm text-dark-400">
-          Loading skill catalog...
-        </div>
+        <SkeletonCardGrid count={6} />
       ) : filtered.length > 0 ? (
         <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
           {filtered.map((skill) => (

--- a/apps/web/app/marketplace/page.tsx
+++ b/apps/web/app/marketplace/page.tsx
@@ -19,6 +19,7 @@ import {
   Terminal,
 } from "lucide-react";
 import { Badge } from "@/components/Badge";
+import { SkeletonCardGrid } from "@/components/Skeleton";
 
 interface MarketplaceSkill {
   id: string;
@@ -218,9 +219,7 @@ export default function MarketplacePage() {
       </div>
 
       {isLoading ? (
-        <div className="rounded-xl border border-dark-700 bg-dark-800 px-5 py-12 text-center text-sm text-dark-400">
-          Loading live skill catalog...
-        </div>
+        <SkeletonCardGrid count={6} />
       ) : filtered.length > 0 ? (
         <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
           {filtered.map((skill) => (

--- a/apps/web/components/Skeleton.tsx
+++ b/apps/web/components/Skeleton.tsx
@@ -1,0 +1,65 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * Skeleton — a low-key shimmer placeholder for content that is loading.
+ *
+ * Uses `animate-pulse` (already covered by the global prefers-reduced-motion
+ * guard, so it stills for motion-sensitive users) and is marked aria-hidden so
+ * screen readers ignore the placeholder. Pair with an aria-live "Loading…"
+ * status elsewhere if you need an announcement.
+ */
+export function Skeleton({ className }: { className?: string }) {
+  return (
+    <div
+      aria-hidden="true"
+      className={cn("animate-pulse rounded-md bg-dark-700/60", className)}
+    />
+  );
+}
+
+/**
+ * SkeletonCard — a placeholder shaped like the catalog/list cards used across
+ * the dashboard (icon + title + description lines), so loading states don't
+ * shift the layout when real content arrives.
+ */
+export function SkeletonCard({ className }: { className?: string }) {
+  return (
+    <div
+      aria-hidden="true"
+      className={cn(
+        "rounded-xl border border-dark-700 bg-dark-800 p-5 space-y-4",
+        className,
+      )}
+    >
+      <div className="flex items-start gap-3">
+        <Skeleton className="w-10 h-10 rounded-lg shrink-0" />
+        <div className="flex-1 space-y-2 pt-1">
+          <Skeleton className="h-3.5 w-2/3" />
+          <Skeleton className="h-3 w-1/3" />
+        </div>
+      </div>
+      <div className="space-y-2">
+        <Skeleton className="h-3 w-full" />
+        <Skeleton className="h-3 w-5/6" />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * SkeletonCardGrid — a responsive grid of {@link SkeletonCard}s matching the
+ * catalog grid (`md:grid-cols-2 xl:grid-cols-3`).
+ */
+export function SkeletonCardGrid({ count = 6 }: { count?: number }) {
+  return (
+    <div
+      role="status"
+      aria-label="Loading"
+      className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4"
+    >
+      {Array.from({ length: count }).map((_, i) => (
+        <SkeletonCard key={i} />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

UI polish **wave 4** — a reusable skeleton-loading system, replacing bare "Loading…" text with layout-matching placeholders so pages don't jump when content arrives.

## Changes
- **New `Skeleton` / `SkeletonCard` / `SkeletonCardGrid`** components. Skeletons use `animate-pulse` (covered by the global `prefers-reduced-motion` guard) and are `aria-hidden`; `SkeletonCardGrid` carries `role="status"` + `aria-label="Loading"` so assistive tech still gets a loading announcement.
- **Marketplace** and **dashboard → Skills** pages now render a `SkeletonCardGrid` mirroring the real `md:2 / xl:3` card grid during load — eliminating the blank-box-then-pop layout shift.

No API or behavior changes — visual/loading only.

## Verification
- web `typecheck` → clean
- `next build` → compiled successfully, **28/28 static pages**

Part of the ongoing series of real, reviewable UI waves — one green PR each. The new `Skeleton` is reusable, so subsequent waves can adopt it across other loading states.

https://claude.ai/code/session_01Fjnt1mevfNwTgyEBEQDzku

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fjnt1mevfNwTgyEBEQDzku)_