### PR TITLE
feat(web): extend skeleton loading to agents and workflows

### DIFF
--- a/apps/web/app/dashboard/agents/page.tsx
+++ b/apps/web/app/dashboard/agents/page.tsx
@@ -10,6 +10,7 @@ import {
 import { formatRelativeTime } from "@/lib/utils";
 import { Badge } from "@/components/Badge";
 import { Modal } from "@/components/Modal";
+import { SkeletonCardGrid } from "@/components/Skeleton";
 
 interface Agent {
   id: string;
@@ -87,9 +88,7 @@ export default function AgentsPage() {
 
       {/* Agent grid */}
       {isLoading ? (
-        <div className="rounded-xl border border-dark-700 bg-dark-800 px-5 py-12 text-center text-sm text-dark-400">
-          Loading agent catalog...
-        </div>
+        <SkeletonCardGrid count={6} />
       ) : agents.length > 0 ? (
         <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
           {agents.map((agent) => (

--- a/apps/web/app/workflows/page.tsx
+++ b/apps/web/app/workflows/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { cn, formatRelativeTime } from "@/lib/utils";
 import { Plus, Play, Pause, Clock, Zap, GitBranch, Trash2 } from "lucide-react";
+import { SkeletonList } from "@/components/Skeleton";
 
 interface Workflow {
   id: string;
@@ -260,9 +261,7 @@ export default function WorkflowsPage() {
       </div>
 
       {isLoading ? (
-        <div className="rounded-xl border border-dark-700 bg-dark-800 px-5 py-12 text-center text-sm text-dark-400">
-          Loading live workflows...
-        </div>
+        <SkeletonList count={4} />
       ) : workflows.length > 0 ? (
         <div className="space-y-3">
           {workflows.map((workflow) => {

--- a/apps/web/components/Skeleton.tsx
+++ b/apps/web/components/Skeleton.tsx
@@ -63,3 +63,36 @@ export function SkeletonCardGrid({ count = 6 }: { count?: number }) {
     </div>
   );
 }
+
+/**
+ * SkeletonListRow — a placeholder shaped like the full-width row cards used in
+ * list views (icon + title/subtitle + trailing action).
+ */
+export function SkeletonListRow({ className }: { className?: string }) {
+  return (
+    <div
+      aria-hidden="true"
+      className={cn("rounded-xl border border-dark-700 bg-dark-800 p-5", className)}
+    >
+      <div className="flex items-center gap-3">
+        <Skeleton className="w-10 h-10 rounded-lg shrink-0" />
+        <div className="flex-1 space-y-2">
+          <Skeleton className="h-3.5 w-1/3" />
+          <Skeleton className="h-3 w-1/2" />
+        </div>
+        <Skeleton className="h-8 w-20 rounded-md shrink-0" />
+      </div>
+    </div>
+  );
+}
+
+/** SkeletonList — a stack of {@link SkeletonListRow}s for vertical list views. */
+export function SkeletonList({ count = 4 }: { count?: number }) {
+  return (
+    <div role="status" aria-label="Loading" className="space-y-3">
+      {Array.from({ length: count }).map((_, i) => (
+        <SkeletonListRow key={i} />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

UI polish **wave 5** — extends the shared skeleton-loading system (from #636) to more pages and adds a list-shaped variant.

## Changes
- **New `SkeletonListRow` / `SkeletonList`** (icon + title/subtitle + trailing action), `role="status"` + `aria-label="Loading"`, reduced-motion-safe.
- **Agents page**: bare "Loading agent catalog…" → `SkeletonCardGrid` matching the `md:2 / xl:3` agent grid.
- **Workflows page**: bare "Loading live workflows…" → `SkeletonList` matching the vertical workflow row layout.

No API or behavior changes — visual/loading only.

## Verification
- web `typecheck` → clean
- `next build` → compiled successfully, **28/28 static pages**

Part of the ongoing series of real, reviewable UI waves — one green PR each. More loading states (observability, evals, usage, etc.) remain as follow-up waves.

https://claude.ai/code/session_01Fjnt1mevfNwTgyEBEQDzku

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fjnt1mevfNwTgyEBEQDzku)_