### PR TITLE
feat(web): skeleton loading for evals, usage, observability

### DIFF
--- a/apps/web/app/dashboard/evals/page.tsx
+++ b/apps/web/app/dashboard/evals/page.tsx
@@ -14,6 +14,7 @@ import { LineChart } from "@/components/Chart";
 import { StatsCard } from "@/components/StatsCard";
 import { Badge } from "@/components/Badge";
 import { DataTable, type Column } from "@/components/DataTable";
+import { SkeletonList } from "@/components/Skeleton";
 import { cn, formatCost, formatDate } from "@/lib/utils";
 
 type EvalStatus = "passed" | "failed" | "running" | "error";
@@ -267,9 +268,7 @@ export default function EvalsPage() {
       </div>
 
       {isLoading ? (
-        <div className="rounded-xl border border-dark-700 bg-dark-800 px-5 py-12 text-center text-sm text-dark-400">
-          Loading eval runs...
-        </div>
+        <SkeletonList count={6} />
       ) : (
         <DataTable
           columns={columns}

--- a/apps/web/app/dashboard/usage/page.tsx
+++ b/apps/web/app/dashboard/usage/page.tsx
@@ -12,6 +12,7 @@ import {
 import { BarChart, LineChart, PieChart } from "@/components/Chart";
 import { StatsCard } from "@/components/StatsCard";
 import { Badge } from "@/components/Badge";
+import { SkeletonStatsRow, SkeletonList } from "@/components/Skeleton";
 import { cn, formatCost, formatDate, formatTokens } from "@/lib/utils";
 
 type RangeKey = "24h" | "7d" | "30d" | "90d";
@@ -179,8 +180,9 @@ export default function UsagePage() {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center h-full text-dark-400">
-        Loading usage...
+      <div className="p-4 sm:p-6 space-y-4 sm:space-y-6 overflow-y-auto h-full">
+        <SkeletonStatsRow count={4} />
+        <SkeletonList count={4} />
       </div>
     );
   }

--- a/apps/web/app/observability/page.tsx
+++ b/apps/web/app/observability/page.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import { Badge } from "@/components/Badge";
 import { StatsCard } from "@/components/StatsCard";
+import { SkeletonStatsRow, SkeletonList } from "@/components/Skeleton";
 import { cn, formatCost, formatDate, formatRelativeTime, formatTokens } from "@/lib/utils";
 
 type StatusFilter = "all" | "ok" | "error" | "active";
@@ -241,8 +242,9 @@ export default function ObservabilityPage() {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center h-full text-dark-400">
-        Loading traces...
+      <div className="p-4 sm:p-6 space-y-4 sm:space-y-6 overflow-y-auto h-full">
+        <SkeletonStatsRow count={4} />
+        <SkeletonList count={6} />
       </div>
     );
   }

--- a/apps/web/components/Skeleton.tsx
+++ b/apps/web/components/Skeleton.tsx
@@ -96,3 +96,28 @@ export function SkeletonList({ count = 4 }: { count?: number }) {
     </div>
   );
 }
+
+/**
+ * SkeletonStatsRow — a placeholder row of stat cards, matching the
+ * `StatsCard` strip many analytics/usage pages lead with.
+ */
+export function SkeletonStatsRow({ count = 4 }: { count?: number }) {
+  return (
+    <div
+      role="status"
+      aria-label="Loading"
+      className="grid grid-cols-2 lg:grid-cols-4 gap-4"
+    >
+      {Array.from({ length: count }).map((_, i) => (
+        <div
+          key={i}
+          aria-hidden="true"
+          className="rounded-xl border border-dark-700 bg-dark-800 p-5 space-y-3"
+        >
+          <Skeleton className="h-3 w-1/2" />
+          <Skeleton className="h-7 w-2/3" />
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

UI polish **wave 6** — skeleton loading for the analytics-style pages, plus a stat-card row variant.

## Changes
- **New `SkeletonStatsRow`** (2/4-up grid of stat-card placeholders) matching the `StatsCard` strips these pages lead with; `role="status"`, reduced-motion-safe.
- **Evals**: "Loading eval runs…" → `SkeletonList` (reads like the `DataTable` rows that follow).
- **Usage** + **Observability**: full-page "Loading…" early-returns → padded `SkeletonStatsRow` + `SkeletonList` mirroring each page's real layout, removing the centered-text flash before content.

No API or behavior changes — visual/loading only.

## Verification
- web `typecheck` → clean
- `next build` → compiled successfully, **28/28 static pages**

Part of the ongoing series of real, reviewable UI waves — one green PR each.

https://claude.ai/code/session_01Fjnt1mevfNwTgyEBEQDzku

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fjnt1mevfNwTgyEBEQDzku)_