### PR TITLE
feat(web): shared EmptyState component for no-data views

### DIFF
--- a/apps/web/app/dashboard/agents/page.tsx
+++ b/apps/web/app/dashboard/agents/page.tsx
@@ -11,6 +11,7 @@ import { formatRelativeTime } from "@/lib/utils";
 import { Badge } from "@/components/Badge";
 import { Modal } from "@/components/Modal";
 import { SkeletonCardGrid } from "@/components/Skeleton";
+import { EmptyState } from "@/components/EmptyState";
 
 interface Agent {
   id: string;
@@ -180,9 +181,11 @@ export default function AgentsPage() {
           ))}
         </div>
       ) : (
-        <div className="rounded-xl border border-dark-700 bg-dark-800 px-5 py-12 text-center text-sm text-dark-400">
-          No agents discovered yet.
-        </div>
+        <EmptyState
+          icon={<Bot size={22} />}
+          title="No agents discovered yet"
+          description="Agents become visible here once they connect to the gateway."
+        />
       )}
 
       {/* Edit modal */}

--- a/apps/web/app/workflows/page.tsx
+++ b/apps/web/app/workflows/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { cn, formatRelativeTime } from "@/lib/utils";
 import { Plus, Play, Pause, Clock, Zap, GitBranch, Trash2 } from "lucide-react";
 import { SkeletonList } from "@/components/Skeleton";
+import { EmptyState } from "@/components/EmptyState";
 
 interface Workflow {
   id: string;
@@ -336,9 +337,11 @@ export default function WorkflowsPage() {
           })}
         </div>
       ) : (
-        <div className="rounded-xl border border-dark-700 bg-dark-800 px-5 py-12 text-center text-sm text-dark-400">
-          No workflows are registered yet.
-        </div>
+        <EmptyState
+          icon={<GitBranch size={22} />}
+          title="No workflows yet"
+          description="Workflows you register will appear here, ready to run and schedule."
+        />
       )}
     </div>
   );

--- a/apps/web/components/EmptyState.tsx
+++ b/apps/web/components/EmptyState.tsx
@@ -1,0 +1,44 @@
+import { cn } from "@/lib/utils";
+
+interface EmptyStateProps {
+  /** Optional icon (e.g. a lucide icon element) shown in a tinted bubble. */
+  icon?: React.ReactNode;
+  /** Primary message — what's empty. */
+  title: string;
+  /** Optional supporting line giving context or a next step. */
+  description?: string;
+  /** Optional call-to-action (button / link). */
+  action?: React.ReactNode;
+  className?: string;
+}
+
+/**
+ * EmptyState — a consistent, friendly placeholder for "no data yet" views.
+ *
+ * Replaces the ad-hoc centered-text empty blocks scattered across the dashboard
+ * with a single component: tinted icon bubble, title, optional description, and
+ * an optional action. Keeps the existing card chrome (rounded border + dark
+ * surface) so it drops into the same slots without layout changes.
+ */
+export function EmptyState({ icon, title, description, action, className }: EmptyStateProps) {
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-dark-700 bg-dark-800 px-5 py-12",
+        "flex flex-col items-center justify-center text-center",
+        className,
+      )}
+    >
+      {icon && (
+        <div className="flex items-center justify-center w-12 h-12 rounded-xl bg-dark-700/70 text-dark-300 mb-4">
+          {icon}
+        </div>
+      )}
+      <p className="text-sm font-medium text-dark-200">{title}</p>
+      {description && (
+        <p className="mt-1 text-sm text-dark-400 max-w-sm">{description}</p>
+      )}
+      {action && <div className="mt-4">{action}</div>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

UI polish **wave 7** — a reusable `EmptyState` component, replacing ad-hoc centered-text "no data" blocks with a consistent, friendlier pattern.

## Changes
- **New `EmptyState`** — tinted icon bubble + title + optional description + optional action, reusing the existing card chrome so it drops into the same slots without layout changes.
- **Workflows**: "No workflows are registered yet." → `EmptyState` with a `GitBranch` icon and a helpful description.
- **Agents**: "No agents discovered yet." → `EmptyState` with a `Bot` icon and context on when agents appear.

No API or behavior changes — visual only.

## Verification
- web `typecheck` → clean
- `next build` → compiled successfully, **28/28 static pages**

Part of the ongoing series of real, reviewable UI waves — one green PR each. `EmptyState` is reusable, so later waves can adopt it across the remaining empty views (dashboard, settings, sessions, etc.).

https://claude.ai/code/session_01Fjnt1mevfNwTgyEBEQDzku

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fjnt1mevfNwTgyEBEQDzku)_