### PR TITLE
feat(web): bare empty-state variant + adopt on dashboard panels

### DIFF
--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -12,6 +12,7 @@ import {
 import { StatsCard } from "@/components/StatsCard";
 import { LineChart } from "@/components/Chart";
 import { Badge } from "@/components/Badge";
+import { EmptyState } from "@/components/EmptyState";
 import { formatCost, formatTokens, formatRelativeTime } from "@/lib/utils";
 
 interface DashboardData {
@@ -265,9 +266,13 @@ export default function DashboardPage() {
               height={260}
             />
           ) : (
-            <div className="flex items-center justify-center h-[260px] rounded-lg bg-dark-700/30 text-sm text-dark-400">
-              No message history yet.
-            </div>
+            <EmptyState
+              bare
+              icon={<MessageSquare size={22} />}
+              title="No message history yet"
+              description="Conversations will chart here as your agents start handling messages."
+              className="h-[260px] rounded-lg bg-dark-700/30 py-0"
+            />
           )}
         </div>
 
@@ -295,9 +300,11 @@ export default function DashboardPage() {
               ))}
             </div>
           ) : (
-            <div className="rounded-lg bg-dark-700/30 px-3 py-8 text-center text-sm text-dark-400">
-              No active channels yet.
-            </div>
+            <EmptyState
+              bare
+              title="No active channels yet"
+              className="rounded-lg bg-dark-700/30 py-8"
+            />
           )}
         </div>
       </div>
@@ -321,9 +328,11 @@ export default function DashboardPage() {
             ))}
           </div>
         ) : (
-          <div className="rounded-lg bg-dark-700/30 px-3 py-8 text-center text-sm text-dark-400">
-            No recent activity captured yet.
-          </div>
+          <EmptyState
+            bare
+            title="No recent activity captured yet"
+            className="rounded-lg bg-dark-700/30 py-8"
+          />
         )}
       </div>
     </div>

--- a/apps/web/components/EmptyState.tsx
+++ b/apps/web/components/EmptyState.tsx
@@ -9,6 +9,11 @@ interface EmptyStateProps {
   description?: string;
   /** Optional call-to-action (button / link). */
   action?: React.ReactNode;
+  /**
+   * Drop the card chrome (border + dark surface). Use when nesting inside an
+   * existing card/panel so the empty state doesn't render a card-in-a-card.
+   */
+  bare?: boolean;
   className?: string;
 }
 
@@ -20,12 +25,12 @@ interface EmptyStateProps {
  * an optional action. Keeps the existing card chrome (rounded border + dark
  * surface) so it drops into the same slots without layout changes.
  */
-export function EmptyState({ icon, title, description, action, className }: EmptyStateProps) {
+export function EmptyState({ icon, title, description, action, bare, className }: EmptyStateProps) {
   return (
     <div
       className={cn(
-        "rounded-xl border border-dark-700 bg-dark-800 px-5 py-12",
-        "flex flex-col items-center justify-center text-center",
+        "px-5 py-12 flex flex-col items-center justify-center text-center",
+        !bare && "rounded-xl border border-dark-700 bg-dark-800",
         className,
       )}
     >


### PR DESCRIPTION
## Summary

UI polish **wave 8** — a `bare` variant for `EmptyState` (so it nests cleanly inside existing cards) and adoption across the dashboard overview's empty panels.

## Changes
- **`EmptyState` gains a `bare` prop** that drops the card chrome (border + surface), for use inside an existing card/panel without rendering a card-in-a-card.
- **Dashboard overview**: the message-history chart slot, active-channels, and recent-activity empty blocks now use `EmptyState` (`bare`). The message-history slot gets a `MessageSquare` icon + helper copy and keeps its 260px height to avoid layout shift in the chart area.

No API or behavior changes — visual only.

## Verification
- web `typecheck` → clean
- `next build` → compiled successfully, **28/28 static pages**

Part of the ongoing series of real, reviewable UI waves — one green PR each.

https://claude.ai/code/session_01Fjnt1mevfNwTgyEBEQDzku

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fjnt1mevfNwTgyEBEQDzku)_