### PR TITLE
feat(web): skeleton loading for analytics, approvals, moderation, timeline

### DIFF
--- a/apps/web/app/dashboard/analytics/page.tsx
+++ b/apps/web/app/dashboard/analytics/page.tsx
@@ -16,6 +16,7 @@ import { BarChart, LineChart, PieChart } from "@/components/Chart";
 import { StatsCard } from "@/components/StatsCard";
 import { formatCost, formatTokens } from "@/lib/utils";
 import { Badge } from "@/components/Badge";
+import { SkeletonStatsRow, SkeletonList } from "@/components/Skeleton";
 
 type DateRange = "7d" | "14d" | "30d";
 
@@ -210,8 +211,9 @@ export default function AnalyticsPage() {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center h-full text-dark-400">
-        Loading analytics...
+      <div className="p-4 sm:p-6 space-y-4 sm:space-y-6 overflow-y-auto h-full">
+        <SkeletonStatsRow count={4} />
+        <SkeletonList count={4} />
       </div>
     );
   }

--- a/apps/web/app/dashboard/approvals/page.tsx
+++ b/apps/web/app/dashboard/approvals/page.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { ShieldAlert } from "lucide-react";
 import { Badge } from "@/components/Badge";
 import { Modal } from "@/components/Modal";
+import { SkeletonList } from "@/components/Skeleton";
 import {
   formatArgs,
   normalizeApprovals,
@@ -112,9 +113,7 @@ export default function ApprovalsPage() {
       </div>
 
       {isLoading ? (
-        <div className="rounded-xl border border-dark-700 bg-dark-800 px-5 py-12 text-center text-sm text-dark-400">
-          Loading pending approvals...
-        </div>
+        <SkeletonList count={3} />
       ) : approvals.length === 0 ? (
         <div className="rounded-xl border border-dark-700 bg-dark-800 px-5 py-12 text-center text-sm text-dark-400">
           <ShieldAlert size={28} className="mx-auto mb-3 text-success-400" />

--- a/apps/web/app/dashboard/moderation/page.tsx
+++ b/apps/web/app/dashboard/moderation/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Flag, ShieldAlert } from "lucide-react";
 import { Badge } from "@/components/Badge";
 import { formatDate } from "@/lib/utils";
+import { SkeletonList } from "@/components/Skeleton";
 
 interface ModerationItem {
   kind: "filtered" | "reported";
@@ -91,7 +92,7 @@ export default function ModerationPage() {
 
       <div className="space-y-3">
         {isLoading ? (
-          <div className="text-sm text-dark-400">Loading moderation queue...</div>
+          <SkeletonList count={3} />
         ) : visibleItems.length === 0 ? (
           <div className="rounded-md border border-dark-800 bg-dark-900 p-6 text-sm text-dark-400">
             No moderation items match this view.

--- a/apps/web/app/dashboard/timeline/page.tsx
+++ b/apps/web/app/dashboard/timeline/page.tsx
@@ -5,6 +5,7 @@ import { Activity, Coins, Hash, Pause, Play, Sparkles } from "lucide-react";
 import { StatsCard } from "@/components/StatsCard";
 import { RunTimeline, type AgentRun } from "@/components/RunTimeline";
 import { cn, formatCost, formatTokens } from "@/lib/utils";
+import { SkeletonList } from "@/components/Skeleton";
 
 interface TraceListResponse {
   traces?: AgentRun[];
@@ -73,8 +74,8 @@ export default function TimelinePage() {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center h-full text-dark-400">
-        Loading timeline...
+      <div className="p-4 sm:p-6 space-y-3 overflow-y-auto h-full">
+        <SkeletonList count={6} />
       </div>
     );
   }


### PR DESCRIPTION
## Summary

UI polish **wave 9** — finishes rolling the shared skeleton system across the remaining bare "Loading…" states.

## Changes
- **Analytics**: full-page "Loading analytics…" → padded `SkeletonStatsRow` + `SkeletonList` matching the stats-led layout.
- **Approvals**: "Loading pending approvals…" → `SkeletonList`.
- **Moderation**: "Loading moderation queue…" → `SkeletonList`.
- **Timeline**: full-page "Loading timeline…" → `SkeletonList`.

All reuse the existing `role="status"` / reduced-motion-safe skeletons, removing the centered-text flash before content on each page.

No API or behavior changes — visual/loading only.

## Verification
- web `typecheck` → clean
- `next build` → compiled successfully, **28/28 static pages**

Part of the ongoing series of real, reviewable UI waves — one green PR each.

https://claude.ai/code/session_01Fjnt1mevfNwTgyEBEQDzku

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fjnt1mevfNwTgyEBEQDzku)_